### PR TITLE
Change triggers for test and deploy

### DIFF
--- a/workflow-templates/alembic-test-migration-quality-coverage.yml
+++ b/workflow-templates/alembic-test-migration-quality-coverage.yml
@@ -2,11 +2,9 @@ name: Run Pytest with Coverage, Check the Alembic Migration and run the Sonar An
 
 on:
   push:
-    branches-ignore:
-      - main
+    branches:
+      - dev
   pull_request:
-    types:
-      - closed
     branches-ignore:
       - main
 

--- a/workflow-templates/django-test-migration-quality-coverage.yml
+++ b/workflow-templates/django-test-migration-quality-coverage.yml
@@ -2,11 +2,9 @@ name: Run Pytest with Coverage, Check the Django Migration and run the Sonar Ana
 
 on:
   push:
-    branches-ignore:
-      - main
+    branches:
+      - dev
   pull_request:
-    types:
-      - closed
     branches-ignore:
       - main
 

--- a/workflow-templates/tag-docker-kube.yml
+++ b/workflow-templates/tag-docker-kube.yml
@@ -66,10 +66,6 @@ jobs:
 # TODO(REP-2945): Move this step to the repository infra
 # Should only be active for repower-django (add job to 'needs' in deploy-verify)
 #  run-migrations:
-#    if: >
-#      ((github.event_name == 'push') ||
-#      (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') ||
-#      (github.event_name == 'workflow_run' && contains(github.event.workflow_run.conclusion, 'success') && contains(github.event.workflow_run.head_commit.message, '[deploy]')))
 #    uses: repowerednl/.github/.github/workflows/run-kube-migration.yml@main
 #    needs: tag
 #    with:

--- a/workflow-templates/tag-docker-kube.yml
+++ b/workflow-templates/tag-docker-kube.yml
@@ -1,20 +1,24 @@
 name: GitHub Tag, Docker publish build, SSH Deploy
 
 on:
-  push:
-    branches:
-      - main
-      - dev
-      - qa #TODO(REP-2853): temporarily until the rollback workflow is in place
   pull_request:
     branches:
       - main
-      - dev
-      - qa #TODO(REP-2853): temporarily until the rollback workflow is in place
+  push:
+    branches:
+      - main
+  workflow_run:
+    workflows:
+!      - # The name of your test workflow (example: Run Yarn commands (install, check-updates, lint, prettier, test with coverage and/or build with publish) and run the Sonar Analysis)
+    types:
+      - completed
 
 jobs:
   tag:
-    if: ${{ contains(github.event.head_commit.message, '[merge]') || contains(github.event.pull_request.title, '[deploy]') }}
+    if: >
+      ((github.event_name == 'push') ||
+      (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') ||
+      (github.event_name == 'workflow_run' && contains(github.event.workflow_run.conclusion, 'success') && contains(github.event.workflow_run.head_commit.message, '[deploy]')))
     permissions:
       contents: write
     uses: repowerednl/.github/.github/workflows/generate-github-tag.yml@main
@@ -33,7 +37,6 @@ jobs:
   # Repeat steps docker + deploy-verify if there are multiple Dockerfiles
 
   docker:
-    if: ${{ contains(github.event.head_commit.message, '[merge]') || contains(github.event.pull_request.title, '[deploy]') }}
     uses: repowerednl/.github/.github/workflows/docker-build-and-push.yml@main
     needs: tag
     with:
@@ -54,20 +57,25 @@ jobs:
       # docker_secret_6:
 
   github-environment:
-    if: ${{ contains(github.event.head_commit.message, '[merge]') || contains(github.event.pull_request.title, '[deploy]') }}
+    if: >
+      ((github.event_name == 'push') ||
+      (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') ||
+      (github.event_name == 'workflow_run' && contains(github.event.workflow_run.conclusion, 'success') && contains(github.event.workflow_run.head_commit.message, '[deploy]')))
     uses: repowerednl/.github/.github/workflows/determine-environment.yml@main
 
 # TODO(REP-2945): Move this step to the repository infra
 # Should only be active for repower-django (add job to 'needs' in deploy-verify)
 #  run-migrations:
-#    if: ${{ contains(github.event.head_commit.message, '[merge]') || contains(github.event.pull_request.title, '[deploy]') }}
+#    if: >
+#      ((github.event_name == 'push') ||
+#      (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') ||
+#      (github.event_name == 'workflow_run' && contains(github.event.workflow_run.conclusion, 'success') && contains(github.event.workflow_run.head_commit.message, '[deploy]')))
 #    uses: repowerednl/.github/.github/workflows/run-kube-migration.yml@main
 #    needs: tag
 #    with:
 #      tag: ${{ needs.tag.outputs.tag }}
 
   deploy-verify:
-    if: ${{ contains(github.event.head_commit.message, '[merge]') || contains(github.event.pull_request.title, '[deploy]') }}
     uses: repowerednl/.github/.github/workflows/kube-deploy-verify.yml@main
     needs: [github-environment, docker]
     with:

--- a/workflow-templates/tag-docker-ssh.yml
+++ b/workflow-templates/tag-docker-ssh.yml
@@ -1,20 +1,24 @@
 name: GitHub Tag, Docker publish build, SSH Deploy
 
 on:
-  push:
-    branches:
-      - main
-      - dev
-      - qa #TODO(REP-2853): temporarily until the rollback workflow is in place
   pull_request:
     branches:
       - main
-      - dev
-      - qa #TODO(REP-2853): temporarily until the rollback workflow is in place
+  push:
+    branches:
+      - main
+  workflow_run:
+    workflows:
+!      - # The name of your test workflow (example: Run Pytest with Coverage, Check the Alembic Migration and run the Sonar Analysis)
+    types:
+      - completed
 
 jobs:
   tag:
-    if: ${{ contains(github.event.head_commit.message, '[merge]') || contains(github.event.pull_request.title, '[deploy]') }}
+    if: >
+      ((github.event_name == 'push') ||
+      (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') ||
+      (github.event_name == 'workflow_run' && contains(github.event.workflow_run.conclusion, 'success') && contains(github.event.workflow_run.head_commit.message, '[deploy]')))
     permissions:
       contents: write
     uses: repowerednl/.github/.github/workflows/generate-github-tag.yml@main
@@ -34,7 +38,6 @@ jobs:
   # Repeat steps below if there are multiple Dockerfiles and/or docker-compose files
 
   docker:
-    if: ${{ contains(github.event.head_commit.message, '[merge]') || contains(github.event.pull_request.title, '[deploy]') }}
     uses: repowerednl/.github/.github/workflows/docker-build-and-push.yml@main
     needs: tag
     with:
@@ -55,11 +58,13 @@ jobs:
       # docker_secret_6:
 
   environment:
-    if: ${{ contains(github.event.head_commit.message, '[merge]') || contains(github.event.pull_request.title, '[deploy]') }}
+    if: >
+      ((github.event_name == 'push') ||
+      (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') ||
+      (github.event_name == 'workflow_run' && contains(github.event.workflow_run.conclusion, 'success') && contains(github.event.workflow_run.head_commit.message, '[deploy]')))
     uses: repowerednl/.github/.github/workflows/determine-environment.yml@main
 
   deploy:
-    if: ${{ contains(github.event.head_commit.message, '[merge]') || contains(github.event.pull_request.title, '[deploy]') }}
     needs: [ environment, docker, tag ]
     uses: repowerednl/.github/.github/workflows/deploy-docker-compose.yml@main
     with:

--- a/workflow-templates/vue-test-lint-quality-coverage.yml
+++ b/workflow-templates/vue-test-lint-quality-coverage.yml
@@ -1,13 +1,12 @@
-name: Run Yarn commands (install, check-updates, lint, prettier, test with coverage and/or build with publish)  and run the Sonar Analysis
+name: Run Yarn commands (install, check-updates, lint, prettier, test with coverage and/or build with publish) and run the Sonar Analysis
 
 on:
-  workflow_dispatch:
   push:
+    branches:
+      - dev
+  pull_request:
     branches-ignore:
       - main
-  pull_request:
-    types:
-      - closed
 
 jobs:
   yarn-check-lint-prettier-test-publish:


### PR DESCRIPTION
- Always run test except when:
    -  a PR from `dev` to `main` is opened 
    - a PR to main is merged (i.e. release or hotfix)
- A deploy is triggered when:
    - the tests succeed and a commit message contains [deploy] -> to `dev` environment
    - a PR from `dev` to `main` is opened  -> to `qa` environment (temporarily until https://repowerednl.atlassian.net/browse/REP-2855)
    - a PR to main is merged -> to `prod` environment

Note: this deploy strategy will thus only work if:
- the test and deploy workflow templates are both implemented.
- there exists a GitHub `qa` environment

