### PR TITLE
Fix bump workflow for using the NPM_AUTH_TOKEN

### DIFF
--- a/.github/workflows/bump-package-json.yml
+++ b/.github/workflows/bump-package-json.yml
@@ -38,4 +38,4 @@ jobs:
 
       - name: Bump package.json version with tag
         working-directory: ${{ inputs.working_directory }}
-        run: yarn version --no-git-tag-version --new-version ${{ inputs.tag }}
+        run: export NPM_AUTH_TOKEN=${{ secrets.NPM_AUTH_TOKEN }} && yarn version --no-git-tag-version --new-version ${{ inputs.tag }}

--- a/workflow-templates/tag-docker-ssh.yml
+++ b/workflow-templates/tag-docker-ssh.yml
@@ -34,6 +34,7 @@ jobs:
       tag: ${{ needs.tag.outputs.tag }}
       # node_version: # Optional, defaults to "20"
       # working_directory: # Optional, defaults to '.'.
+    secrets: inherit
 
   # Repeat steps below if there are multiple Dockerfiles and/or docker-compose files
 


### PR DESCRIPTION
#patch: setting the yarn version requires the NPM_AUTH_TOKEN to be set. 