### PR TITLE
Fix circular dependency by using propagation method + update templates accordingly

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -11,6 +11,10 @@ on:
       docker_hub_username:
         required: true
         type: string
+      environment:
+        description: The environment the docker image is build for
+        type: string
+        required: true
       # Optional
       dockerfile_name:
         type: string
@@ -31,7 +35,10 @@ on:
     outputs:
       image_tag:
         description: "The docker image tag following the structure: <docker hub username>/<repository>[-<name>]:<semver version>"
-        value: ${{ jobs.generate-image-tag.outputs.image_tag }}
+        value: ${{ jobs.generate-image-tag-set-environment.outputs.image_tag }}
+      environment:
+        description: propagate the environment used in the docker build to (an)other job(s)
+        value: ${{ jobs.generate-image-tag-set-environment.outputs.environment }}
     secrets:
       docker_hub_access_token:
         required: true
@@ -43,10 +50,11 @@ on:
       docker_secret_6:
 
 jobs:
-  generate-image-tag:
+  generate-image-tag-set-environment:
     runs-on: ubuntu-latest
     outputs:
-      image_tag: ${{ steps.docker-image-tag.outputs.image_tag }}
+      image_tag: ${{ steps.docker-image-tag-env.outputs.image_tag }}
+      environment: ${{ steps.docker-image-tag-env.outputs.environment }}
     steps:
       # Sets the docker image tag according to the file system structure of Dockerhub with versioning
       # Examples:
@@ -54,7 +62,7 @@ jobs:
       # - with name (i.e. Dockerfile.foobar): thehubusername/repositoryfoobar-helloworld:v1.0.1.beta.3
       # - Repowered example: repowered/platform-django:v1.0.1.beta.3
       - name: Set docker image tag for '${{ inputs.dockerfile_name }}'
-        id: docker-image-tag
+        id: docker-image-tag-env
         env:
           hub_repo: ${{ inputs.docker_hub_username }}/${{ github.event.repository.name }}
         run: |
@@ -65,6 +73,7 @@ jobs:
           else
             echo "image_tag=${{ env.hub_repo }}${DOCKERFILE_NAME}:${{ inputs.tag }}" >> $GITHUB_OUTPUT
           fi
+          echo "environment=${{ inputs.environment }}" >> $GITHUB_OUTPUT
 
   build-and-push:
     runs-on: ubuntu-latest

--- a/workflow-templates/tag-docker-kube.yml
+++ b/workflow-templates/tag-docker-kube.yml
@@ -7,8 +7,8 @@ on:
   workflow_run:
     workflows:
 !      - # The name of your test workflow (example: Run Yarn commands (install, check-updates, lint, prettier, test with coverage and/or build with publish) and run the Sonar Analysis)
-    types:
-      - completed
+  types:
+    - completed
 
 run-name: Deploy branch ${{ github.event.workflow_run.head_branch }} by @${{ github.actor }}
 
@@ -19,7 +19,7 @@ jobs:
     uses: repowerednl/.github/.github/workflows/generate-github-tag.yml@main
 
   # Only for the front-end; delete this job if you don't have a 'package.json'
-  # If you do, add bump to the 'needs' section -> needs: [tag, bump]
+  # If you do, add bump to the 'needs' section for docker -> needs: [tag, bump]
   bump:
     permissions:
       contents: write
@@ -32,12 +32,16 @@ jobs:
 
   # Repeat steps docker + deploy-verify if there are multiple Dockerfiles
 
+  github-environment:
+    uses: repowerednl/.github/.github/workflows/determine-environment.yml@main
+
   docker:
     uses: repowerednl/.github/.github/workflows/docker-build-and-push.yml@main
-    needs: tag
+    needs: [ tag, github-environment ]
     with:
       tag: ${{ needs.tag.outputs.tag }}
       docker_hub_username: ${{ vars.DOCKER_HUB_USERNAME }}
+      environment: ${{ needs.github-environment.outputs.environment }}
       # dockerfile_name: # Optional, defaults to 'Dockerfile'
       # build_argument_one: # Optional, no default; from GitHub Variables
       # build_argument_two: # Optional, no default; from GitHub Variables
@@ -52,20 +56,17 @@ jobs:
       # docker_secret_5:
       # docker_secret_6:
 
-  github-environment:
-    uses: repowerednl/.github/.github/workflows/determine-environment.yml@main
-
-# TODO(REP-2945): Move this step to the repository infra
-# Should only be active for repower-django (add job to 'needs' in deploy-verify)
-#  run-migrations:
-#    uses: repowerednl/.github/.github/workflows/run-kube-migration.yml@main
-#    needs: tag
-#    with:
-#      tag: ${{ needs.tag.outputs.tag }}
+  # TODO(REP-2945): Move this step to the repository infra
+  # Should only be active for repower-django (add job to 'needs' in deploy-verify)
+  #  run-migrations:
+  #    uses: repowerednl/.github/.github/workflows/run-kube-migration.yml@main
+  #    needs: tag
+  #    with:
+  #      tag: ${{ needs.tag.outputs.tag }}
 
   deploy-verify:
     uses: repowerednl/.github/.github/workflows/kube-deploy-verify.yml@main
-    needs: [github-environment, docker]
+    needs: [ docker ]
     with:
       # If there are multiple deployments for a single docker image, the container names can be specified here
       # Example:
@@ -73,7 +74,7 @@ jobs:
       # the corresponding container_names are: "['foo', 'bar']"
       container_names: # A JSON list string i.e. "['my name']"
       docker_image_tag: ${{ needs.docker.outputs.image_tag }}
-      environment: ${{ needs.github-environment.outputs.environment }}
+      environment: ${{ needs.docker.outputs.environment }}
       # with_infisical_configuration: # Optional, defaults to false
     secrets:
       digital_ocean_access_token: ${{ secrets.DIGITAL_OCEAN_ACCESS_TOKEN }}

--- a/workflow-templates/tag-docker-ssh.yml
+++ b/workflow-templates/tag-docker-ssh.yml
@@ -32,13 +32,16 @@ jobs:
       # working_directory: # Optional, defaults to '.'.
 
   # Repeat steps below if there are multiple Dockerfiles and/or docker-compose files
+  github-environment:
+    uses: repowerednl/.github/.github/workflows/determine-environment.yml@main
 
   docker:
     uses: repowerednl/.github/.github/workflows/docker-build-and-push.yml@main
-    needs: tag
+    needs: [tag, github-environment]
     with:
       tag: ${{ needs.tag.outputs.tag }}
       docker_hub_username: ${{ vars.DOCKER_HUB_USERNAME }}
+      environment: ${{ needs.github-environment.outputs.environment }}
       # dockerfile_name: # Optional, defaults to 'Dockerfile'
       # build_argument_one: # Optional, no default; from GitHub Variables
       # build_argument_two: # Optional, no default; from GitHub Variables
@@ -53,14 +56,11 @@ jobs:
       # docker_secret_5:
       # docker_secret_6:
 
-  environment:
-    uses: repowerednl/.github/.github/workflows/determine-environment.yml@main
-
   deploy:
-    needs: [ environment, docker, tag ]
+    needs: [ docker, tag ]
     uses: repowerednl/.github/.github/workflows/deploy-docker-compose.yml@main
     with:
-      environment: ${{ needs.environment.outputs.environment }}
+      environment: ${{ needs.docker.outputs.environment }}
       tag: ${{ needs.tag.outputs.tag }}
       # server_username: Optional, defaults to 'root'
       # docker-compose_remote_dir: Optional, defaults to '/root'


### PR DESCRIPTION
#patch: Fix circular dependency for github-environment

To use this variant with propagation; in your template, do:
1. Set the environment input for the docker job
2. All jobs after the docker job, don't needs 'github-environment' but use `environment: ${{ needs.docker.outputs.environment }}