### PR TITLE
Sonar update

### DIFF
--- a/.github/workflows/quality-control-sonar.yml
+++ b/.github/workflows/quality-control-sonar.yml
@@ -22,11 +22,6 @@ jobs:
         with:
           name: ${{ inputs.coverage_report_name }}
 
-      - name: Display structure of downloaded files
-        run: |
-          ls -alhR 
-          pwd
-
       - name: SonarCloud analysis
         uses: SonarSource/sonarcloud-github-action@master
         env:

--- a/.github/workflows/quality-control-sonar.yml
+++ b/.github/workflows/quality-control-sonar.yml
@@ -13,17 +13,19 @@ jobs:
     runs-on: ubuntu-latest
     name: Quality checks via SonarCloud with coverage report
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+
       - name: Download coverage artifact
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.coverage_report_name }}
 
       - name: Display structure of downloaded files
-        run: ls -R
-
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+        run: |
+          ls -alhR 
+          pwd
 
       - name: SonarCloud analysis
         uses: SonarSource/sonarcloud-github-action@master

--- a/.github/workflows/quality-control-sonar.yml
+++ b/.github/workflows/quality-control-sonar.yml
@@ -18,6 +18,9 @@ jobs:
         with:
           name: ${{ inputs.coverage_report_name }}
 
+      - name: Display structure of downloaded files
+        run: ls -R
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis


### PR DESCRIPTION
#patch: checkout action clears workspace, so download artifact after checkout

See succesfull run: https://github.com/repowerednl/repower-django/actions/runs/12161271137/job/33915920015?pr=1280#step:6:97