### PR TITLE
Fix wrong 'generate-image....' job reference

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -77,7 +77,7 @@ jobs:
 
   build-and-push:
     runs-on: ubuntu-latest
-    needs: generate-image-tag
+    needs: generate-image-tag-set-environment
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -96,7 +96,7 @@ jobs:
           context: "{{defaultContext}}:./"
           file: ${{ inputs.dockerfile_name }}
           push: true
-          tags: ${{ needs.generate-image-tag.outputs.image_tag }}
+          tags: ${{ needs.generate-image-tag-set-environment.outputs.image_tag }}
           build-args: |
             ARG_1=${{ inputs.build_argument_one }}
             ARG_2=${{ inputs.build_argument_two }}


### PR DESCRIPTION
#### #patch: Rename incorrect job references 'generate-image-tag' to 'generate-image-tag-set-environment'

Follow-up to #18