### PR TITLE
Move the creation of secrets to the migration job and remove from dep…

### DIFF
--- a/.github/workflows/deploy-verify-kubernetes.yml
+++ b/.github/workflows/deploy-verify-kubernetes.yml
@@ -14,20 +14,9 @@ on:
       environment:
         type: string
         required: true
-      # Optional
-      with_infisical_configuration:
-        type: boolean
-        required: false
-        default: false
     secrets:
       digital_ocean_access_token:
         required: true
-      infisical_client_id:
-        required: false
-      infisical_client_client_secret:
-        required: false
-      infisical_client_project_id:
-        required: false
 
 jobs:
   deploy-verify:
@@ -46,21 +35,6 @@ jobs:
         env:
           expiry-seconds: ${{ vars.KUBE_CRED_EXPIRY_SECOND || 300 }}
         run: doctl kubernetes cluster kubeconfig save  --expiry-seconds ${{ env.expiry-seconds }} ${{ vars.CLUSTER_NAME }}
-
-      - name: Update kubernetes secrets
-        if: ${{ inputs.with_infisical_configuration == true }}
-        run: |
-          kubectl delete secret infisical-secrets --ignore-not-found=true
-          if ! kubectl get secret infisical-secrets > /dev/null 2>&1; then
-            echo "Secret not found. Creating it now..."
-            kubectl create secret generic infisical-secrets \
-              --from-literal=INFISICAL_CLIENT_ID=${{ secrets.infisical_client_id }} \
-              --from-literal=INFISICAL_CLIENT_SECRET=${{ secrets.infisical_client_client_secret }} \
-              --from-literal=INFISICAL_PROJECT_ID=${{ secrets.infisical_client_project_id }}
-            echo "Secret created successfully."
-          else
-            echo "Secret already exists. It was created in another job"
-          fi
 
       - name: Deploy ${{ matrix.container_name }}
         run: | 

--- a/.github/workflows/run-kube-migration.yml
+++ b/.github/workflows/run-kube-migration.yml
@@ -11,6 +11,15 @@ on:
       environment:
         type: string
         required: true
+    secrets:
+      digital_ocean_access_token:
+        required: true
+      infisical_client_id:
+        required: false
+      infisical_client_client_secret:
+        required: false
+      infisical_client_project_id:
+        required: false
 
 jobs:
   migraties:
@@ -32,10 +41,26 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - name: Update kubernetes secrets
+        run: |
+          kubectl delete secret infisical-secrets --ignore-not-found=true
+          if ! kubectl get secret infisical-secrets > /dev/null 2>&1; then
+            echo "Secret not found. Creating it now..."
+            kubectl create secret generic infisical-secrets \
+              --from-literal=INFISICAL_CLIENT_ID=${{ secrets.infisical_client_id }} \
+              --from-literal=INFISICAL_CLIENT_SECRET=${{ secrets.infisical_client_client_secret }} \
+              --from-literal=INFISICAL_PROJECT_ID=${{ secrets.infisical_client_project_id }}
+            echo "Secret created successfully."
+          else
+            echo "Secret already exists. It was created in another job"
+          fi
+
       - name: Run migrations job
         run: cat migrations_job.yml | envsubst | kubectl apply -f -
         env:
           VERSION: ${{ inputs.tag }}
 
       - name: Verify migrations are successful
-        run: kubectl wait --for=condition=complete --timeout=300s job/django-migrations-${{inputs.tag}}
+        env:
+          timeout-seconds: ${{ vars.MIGRATION_TIMEOUT_SECONDS || 300s }}
+        run: kubectl wait --for=condition=complete --timeout=${{ env.timeout-seconds }} job/django-migrations-${{inputs.tag}}

--- a/workflow-templates/tag-docker-kube.yml
+++ b/workflow-templates/tag-docker-kube.yml
@@ -58,15 +58,19 @@ jobs:
       # docker_secret_5:
       # docker_secret_6:
 
-  # TODO(REP-2945): Move this step to the repository infra
-  # Should only be active for repower-django (add job to 'needs' in deploy-verify)
-  #  run-migrations:
-  #    uses: repowerednl/.github/.github/workflows/run-kube-migration.yml@main
-  #    needs: [tag, github-environment]
-  #    with:
-  #      tag: ${{ needs.tag.outputs.tag }}
-  #      environment: ${{ inputs.environment }}
-  #    secrets: inherit
+#   TODO(REP-2945): Move this step to the repository infra
+#   Should only be active for repower-django (add job to 'needs' in deploy-verify)
+    run-migrations:
+      uses: repowerednl/.github/.github/workflows/run-kube-migration.yml@main
+      needs: [tag, github-environment]
+      with:
+        tag: ${{ needs.tag.outputs.tag }}
+        environment: ${{ needs.github-environment.outputs.environment }}
+      secrets:
+        digital_ocean_access_token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+        infisical_client_id: ${{ secrets.INFISICAL_CLIENT_ID }}
+        infisical_client_client_secret: ${{ secrets.INFISICAL_CLIENT_SECRET }}
+        infisical_client_project_id: ${{ secrets.INFISICAL_PROJECT_ID }}
 
   deploy-verify:
     uses: repowerednl/.github/.github/workflows/deploy-verify-kubernetes.yml@main
@@ -79,9 +83,5 @@ jobs:
       container_names: # A JSON list string i.e. "['my name']"
       docker_image_tag: ${{ needs.docker.outputs.image_tag }}
       environment: ${{ needs.docker.outputs.environment }}
-      # with_infisical_configuration: # Optional, defaults to false
     secrets:
       digital_ocean_access_token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
-      # infisical_client_id: ${{ secrets.INFISICAL_CLIENT_ID }}
-      # infisical_client_client_secret: ${{ secrets.INFISICAL_CLIENT_SECRET }}
-      # infisical_client_project_id: ${{ secrets.INFISICAL_PROJECT_ID }}


### PR DESCRIPTION
#major: will break current repower-django workflow on merge to main. 

Test by changing the migration's and deploy job's tag from `@main` to `@REP-3441-Fix...`. and apply the changes in the template `tag-docker-kube` to the used template. 

Also, make the migration time-out configurable per environment.

Fixes: https://repowerednl.atlassian.net/browse/REP-3441

