### PR TITLE
Add labeled deploy

### DIFF
--- a/.github/workflows/determine-environment.yml
+++ b/.github/workflows/determine-environment.yml
@@ -17,7 +17,10 @@ jobs:
       pull-requests: read
     outputs:
       env_name: ${{ steps.retrieve-environment.outputs.env_name }}
-    if: ${{ github.event_name == 'push' || (contains(github.event.workflow_run.conclusion, 'success') && (contains(github.event.workflow_run.head_branch, 'dev') || contains(github.event.workflow_run.head_commit.message, '[deploy]'))) }}
+    if: ${{ github.event_name == 'push' 
+      || (contains(github.event.workflow_run.conclusion, 'success') && (contains(github.event.workflow_run.head_branch, 'dev') 
+      || contains(github.event.workflow_run.head_commit.message, '[deploy]'))) 
+      || github.event.label.name == 'deploy' }}
     steps:
       - name: Retrieve environment
         id: retrieve-environment

--- a/.github/workflows/generate-github-tag.yml
+++ b/.github/workflows/generate-github-tag.yml
@@ -14,7 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.github-tag.outputs.tag }}
-    if: ${{ github.event_name == 'push' || (contains(github.event.workflow_run.conclusion, 'success') && (contains(github.event.workflow_run.head_branch, 'dev') || contains(github.event.workflow_run.head_commit.message, '[deploy]'))) }}
+    if: ${{ github.event_name == 'push' 
+      || (contains(github.event.workflow_run.conclusion, 'success') && (contains(github.event.workflow_run.head_branch, 'dev') 
+      || contains(github.event.workflow_run.head_commit.message, '[deploy]'))) 
+      || github.event.label.name == 'deploy' }}
     steps:
       # Checkout the repository with all commit history
       - name: Checkout ${{ github.repository }}
@@ -32,4 +35,6 @@ jobs:
           WITH_V: true
           RELEASE_BRANCHES: dev
           DEFAULT_BUMP: patch
-          PRERELEASE: ${{ (!contains(github.event.workflow_run.head_branch, 'dev') || contains(github.event.workflow_run.pull_requests[0].base.ref, 'main')) && contains(github.event.workflow_run.head_commit.message, '[deploy]') }}
+          PRERELEASE: ${{ (!contains(github.event.workflow_run.head_branch, 'dev') 
+            || (contains(github.event.workflow_run.pull_requests[0].base.ref, 'main')) && contains(github.event.workflow_run.head_commit.message, '[deploy]')) 
+            || (contains(github.event.workflow_run.pull_requests[0].base.ref, 'main')) ** github.event.label.name == 'deploy') }}

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -9,11 +9,3 @@ Give a brief summary of the feature or bugfix using the semantic versioning stru
 [UI/UX] Include a media file
 
 [Optionally] Jira ticket link: https://repowerednl.atlassian.net/browse/REP-
-
-### Example (to be removed)
-
-#### #minor: Add model FunnyAnimals
-
-For testing the alembic migration workflow, a model was added without creating a migration.
-
-Now, when running the workflow, the migration test fails (as wanted) resulting in a GitHub Job Summary report, explaining that the migration for FunnyAnimals has not been created.

--- a/workflow-templates/tag-docker-kube.yml
+++ b/workflow-templates/tag-docker-kube.yml
@@ -9,8 +9,11 @@ on:
 !      - # The actual name of your TEST workflow (example: Run Yarn commands (install, check-updates, lint, prettier, test with coverage and/or build with publish) and run the Sonar Analysis)
     types:
       - completed
+  pull_request:
+    types:
+      - labeled
 
-run-name: Deploy branch ${{ github.event.workflow_run.head_branch }} by @${{ github.actor }}
+run-name: Deploy branch ${{ github.event.workflow_run.head_branch || 'main' }} by @${{ github.actor }}
 
 jobs:
   tag:

--- a/workflow-templates/tag-docker-ssh.yml
+++ b/workflow-templates/tag-docker-ssh.yml
@@ -9,8 +9,11 @@ on:
 !      - # The name of your test workflow (example: Run Pytest with Coverage, Check the Alembic Migration and run the Sonar Analysis)
     types:
       - completed
+  pull_request:
+    types:
+      - labeled
 
-run-name: Deploy branch ${{ github.event.workflow_run.head_branch }} by @${{ github.actor }}
+run-name: Deploy branch ${{ github.event.workflow_run.head_branch || 'main' }} by @${{ github.actor }}
 
 jobs:
   tag:


### PR DESCRIPTION
#minor: Add deploy trigger for conditional deploy + template triggers. 
#patch: Fix a bug in the naming of the deploy workflow template
#minor: Remove the example in the PR template (which is inherited by repos unless one is defined on repo level)

Jira ticket link: https://repowerednl.atlassian.net/browse/REP-3442

See workflow runs in the test repository:
https://github.com/repowerednl/workflow-tests/actions
In order workflow run actions:
1+2: Feature branch -> Dev: https://github.com/repowerednl/workflow-tests/pull/8. Test + with and without deploy label
3: Dev branch: test+ auto deploy (no label needed)
4: Dev -> Main release PR: https://github.com/repowerednl/workflow-tests/pull/9. With deploy label)
5. Main branch: auto deploy (no label needed)

Note: on merge not directly active in other repositories. They still need to contain the trigger as shown in the template. The following merge requests contain that (please review :1st_place_medal: ):

- https://github.com/repowerednl/repower-django/pull/1349
- https://github.com/repowerednl/repower-frontend/pull/202
- https://github.com/repowerednl/battery-simulation-tool-frontend/pull/187

Also, he link is a copy of this pr (please review :1st_place_medal: ): https://github.com/repowerednl/.github/pull/27

- [ ]  remove workflow runs in test repository upon merge for clean overview
- [x] create label 'deploy' in GitHub