### PR TITLE
Rep 3986 create reusable workflow for publishing python package

### DIFF
--- a/.github/workflows/deploy-sphinx-documentation.yml
+++ b/.github/workflows/deploy-sphinx-documentation.yml
@@ -1,0 +1,81 @@
+name: Deploy sphinx documentation
+
+on:
+  workflow_call:
+    inputs:
+      file_paths_to_cache:
+        type: string
+        required: true
+      # Provided by caller workflow
+      python_version:
+        type: string
+        required: true
+      poetry_version:
+        type: string
+        required: true
+      docs_target:
+        description: The directory where the package's documentation is stored (usually /home/repowered/docs/<package name>/
+        type: string
+        required: true
+#        default: /home/repowered/docs/rephrase/
+      # Optional
+      docs_host:
+        type: string
+        required: false
+        default: docs.repowered.nl
+      docs_port:
+        type: number
+        required: false
+        default: 22
+      docs_user:
+        type: string
+        required: false
+        default: repowered
+      docs_source:
+        type: string
+        required: false
+        default: docs/_build/html
+    secrets:
+      private_pypi_url:
+        required: true
+      private_pypi_user:
+        required: true
+      private_pypi_password:
+        required: true
+      docs_ssh_private_key:
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: (Cached) Python and Poetry
+        id: cache
+        uses: repowerednl/.github/composite-actions/python-poetry-cache@main
+        with:
+          python_version: ${{ inputs.python_version }}
+          poetry_version: ${{ inputs.poetry_version }}
+          file_paths_to_cache: ${{ inputs.file_paths_to_cache }}
+          private_pypi_url: ${{ secrets.private_pypi_url }}
+          private_pypi_user: ${{ secrets.private_pypi_user }}
+          private_pypi_password: ${{ secrets.private_pypi_password }}
+
+      - name: Build documentation
+        run: |
+          cd docs
+          poetry run make html
+
+      - name: Deploy documentation
+        uses: appleboy/scp-action@v0.1.4
+        with:
+          host: ${{ inputs.docs_host }}
+          port: ${{ inputs.docs_port }}
+          username: ${{ inputs.docs_user }}
+          key: ${{ secrets.docs_ssh_private_key }}
+          source: ${{ inputs.docs_source }}
+          target: ${{ inputs.docs_target }}
+          strip_components: 3  # remove the docs/_build/html part from the path

--- a/.github/workflows/python-test-coverage-simple.yml
+++ b/.github/workflows/python-test-coverage-simple.yml
@@ -39,7 +39,6 @@ jobs:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: (Cached) Python and Poetry
-        id: cache
         uses: repowerednl/.github/composite-actions/python-poetry-cache@main
         with:
           python_version: ${{ inputs.python_version }}

--- a/.github/workflows/python-test-coverage-simple.yml
+++ b/.github/workflows/python-test-coverage-simple.yml
@@ -1,0 +1,82 @@
+name: Pytest with Coverage
+# This is a basic pytest implementation without a postgres service and without parallelization
+
+on:
+  workflow_call:
+    inputs:
+      file_paths_to_cache:
+        type: string
+        required: true
+      # Provided by caller workflow
+      python_version:
+        type: string
+        required: true
+      poetry_version:
+        type: string
+        required: true
+      # Optional
+      working_directory:
+        type: string
+        description: Whenever the app (i.e. manage.py) is not in the root, the location can be specified here
+        default: .
+    secrets:
+      private_pypi_url:
+        required: true
+      private_pypi_user:
+        required: true
+      private_pypi_password:
+        required: true
+
+jobs:
+  pytest-with-coverage:
+    name: Pytest With Postgres and Coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+
+      - name: (Cached) Python and Poetry
+        id: cache
+        uses: repowerednl/.github/composite-actions/python-poetry-cache@main
+        with:
+          python_version: ${{ inputs.python_version }}
+          poetry_version: ${{ inputs.poetry_version }}
+          working_directory: ${{ inputs.working_directory }}
+          file_paths_to_cache: ${{ inputs.file_paths_to_cache }}
+          private_pypi_url: ${{ secrets.private_pypi_url }}
+          private_pypi_user: ${{ secrets.private_pypi_user }}
+          private_pypi_password: ${{ secrets.private_pypi_password }}
+
+      - name: Run tests with coverage
+        working-directory: ${{ inputs.working_directory }}
+        run: |
+          poetry run coverage run -m pytest -v
+        env:
+          pytest_github_report: true
+          pytest_use_blanks: true
+          CI: true
+
+      - name: Upload coverage
+        uses: actions/upload-artifact@v4
+        with:
+          path: ${{ inputs.working_directory }}/.coverage
+          if-no-files-found: 'error'
+          include-hidden-files: true
+          overwrite: true
+
+      - name: Coverage reports
+        working-directory: ${{ inputs.working_directory }}
+        run: |
+          poetry run coverage report
+          poetry run coverage xml
+
+      - name: Coverage comment
+        id: coverage-comment
+        uses: py-cov-action/python-coverage-comment-action@v3
+        with:
+          GITHUB_TOKEN: ${{ github.token }}
+          COVERAGE_PATH: ${{ inputs.working_directory }}
+          MINIMUM_ORANGE: 80

--- a/.github/workflows/python-test-coverage.yml
+++ b/.github/workflows/python-test-coverage.yml
@@ -26,7 +26,7 @@ on:
       # Optional
       working_directory:
         type: string
-        description: Whenever the app (i.e. manage.py) is not in the root; the location can be specified here
+        description: Whenever the app (i.e. manage.py) is not in the root, the location can be specified here
         default: .
       test_groups:
         type: string
@@ -82,7 +82,7 @@ jobs:
 
       - name: (Cached) Python and Poetry
         id: cache
-        uses: repowerednl/.github/composite-actions/python-poetry-cache@REP-3541-Sonarcloud-coverage-rate-is-too-low-and-failing-on-every-PR
+        uses: repowerednl/.github/composite-actions/python-poetry-cache@main
         with:
           python_version: ${{ inputs.python_version }}
           poetry_version: ${{ inputs.poetry_version }}
@@ -116,13 +116,6 @@ jobs:
           if-no-files-found: 'error'
           include-hidden-files: true
           overwrite: true
-
-      - name: Save cache once
-        if: steps.cache.outputs.cache-hit != 'true' && matrix.group == 1
-        uses: actions/cache/save@v4
-        with:
-          path: ${{ inputs.file_paths_to_cache }}
-          key: cache-python-${{ inputs.python_version }}-poetry-${{ inputs.poetry_version }}-${{ hashFiles('**/poetry.lock') }}
 
   combine-and-report:
     needs: pytest-with-coverage

--- a/.github/workflows/release-pypi-package.yml
+++ b/.github/workflows/release-pypi-package.yml
@@ -20,6 +20,8 @@ on:
         required: true
       private_pypi_password:
         required: true
+      publish_pypi_url:
+        required: true
 
 jobs:
   deploy:
@@ -38,6 +40,7 @@ jobs:
         private_pypi_url: ${{ secrets.private_pypi_url }}
         private_pypi_user: ${{ secrets.private_pypi_user }}
         private_pypi_password: ${{ secrets.private_pypi_password }}
+        publish_pypi_url: ${{ secrets.publish_pypi_url }}
 
     - name: Update version
       run: poetry version ${{ github.event.release.tag_name }}

--- a/.github/workflows/release-pypi-package.yml
+++ b/.github/workflows/release-pypi-package.yml
@@ -34,7 +34,6 @@ jobs:
       with:
         python_version: ${{ inputs.python_version }}
         poetry_version: ${{ inputs.poetry_version }}
-        working_directory: ${{ inputs.working_directory }}
         file_paths_to_cache: ${{ inputs.file_paths_to_cache }}
         private_pypi_url: ${{ secrets.private_pypi_url }}
         private_pypi_user: ${{ secrets.private_pypi_user }}

--- a/.github/workflows/release-pypi-package.yml
+++ b/.github/workflows/release-pypi-package.yml
@@ -1,0 +1,48 @@
+name: Release PyPi package
+
+on:
+  workflow_call:
+    inputs:
+      file_paths_to_cache:
+        type: string
+        required: true
+      # Provided by caller workflow
+      python_version:
+        type: string
+        required: true
+      poetry_version:
+        type: string
+        required: true
+    secrets:
+      private_pypi_url:
+        required: true
+      private_pypi_user:
+        required: true
+      private_pypi_password:
+        required: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: (Cached) Python and Poetry
+      id: cache
+      uses: repowerednl/.github/composite-actions/python-poetry-cache@main
+      with:
+        python_version: ${{ inputs.python_version }}
+        poetry_version: ${{ inputs.poetry_version }}
+        working_directory: ${{ inputs.working_directory }}
+        file_paths_to_cache: ${{ inputs.file_paths_to_cache }}
+        private_pypi_url: ${{ secrets.private_pypi_url }}
+        private_pypi_user: ${{ secrets.private_pypi_user }}
+        private_pypi_password: ${{ secrets.private_pypi_password }}
+
+    - name: Update version
+      run: poetry version ${{ github.event.release.tag_name }}
+
+    - name: Build and publish
+      run: |
+        poetry publish --build --no-interaction --repository repowered-pub

--- a/composite-actions/python-poetry-cache/action.yml
+++ b/composite-actions/python-poetry-cache/action.yml
@@ -27,7 +27,9 @@ inputs:
     required: true
   private_pypi_password:
     required: true
-
+  publish_pypi_url:
+    required: false
+    default: ''
 
 runs:
   using: "composite"
@@ -57,13 +59,14 @@ runs:
       working-directory: ${{ inputs.working_directory }}
       shell: bash
       if: steps.cache.outputs.cache-hit != 'true'
-      env:
-        PRIVATE_PYPI_URL: ${{ inputs.private_pypi_url}}
-        PRIVATE_PYPI_USER: ${{ inputs.private_pypi_user}}
-        PRIVATE_PYPI_PASSWORD: ${{ inputs.private_pypi_password}}
       run: |
-        poetry config repositories.repowered $PRIVATE_PYPI_URL
-        poetry config http-basic.repowered $PRIVATE_PYPI_USER $PRIVATE_PYPI_PASSWORD
+        poetry config repositories.repowered ${{ inputs.private_pypi_url }}
+        poetry config http-basic.repowered ${{ inputs.private_pypi_user }} ${{ inputs.private_pypi_password }}
+        if [[ "${{ inputs.publish_pypi_url }}" != '' ]]; then  
+          echo "Configuring poetry publishing"
+          poetry config repositories.repowered-pub ${{ inputs.publish_pypi_url }}
+          poetry config http-basic.repowered-pub ${{ inputs.private_pypi_user }} ${{ inputs.private_pypi_password }}
+        fi
         poetry install --all-extras --no-interaction --no-root --no-ansi
 
     - name: Save cache once

--- a/composite-actions/python-poetry-cache/action.yml
+++ b/composite-actions/python-poetry-cache/action.yml
@@ -64,7 +64,7 @@ runs:
       run: |
         poetry config repositories.repowered $PRIVATE_PYPI_URL
         poetry config http-basic.repowered $PRIVATE_PYPI_USER $PRIVATE_PYPI_PASSWORD
-        poetry install --no-interaction --no-root --no-ansi
+        poetry install --all-extras --no-interaction --no-root --no-ansi
 
     - name: Save cache once
       if: ${{ inputs.save_cache == true && steps.cache.outputs.cache-hit != 'true' }}

--- a/workflow-templates/test-sphinx-release-pypi.json
+++ b/workflow-templates/test-sphinx-release-pypi.json
@@ -1,0 +1,11 @@
+{
+    "name": "Pytest, sphinx docs and release PyPi package",
+    "description": "Run pytest with coverage (without parallelization and postgres services), deploy Sphinx documentation and release the code as a private PyPi package",
+    "iconName": "octicon package-dependents",
+    "categories": ["Repowered"],
+    "filePatterns": [
+        ".*.py",
+        "poetry.lock",
+        "pyproject.toml"
+    ]
+}

--- a/workflow-templates/test-sphinx-release-pypi.yml
+++ b/workflow-templates/test-sphinx-release-pypi.yml
@@ -1,0 +1,70 @@
+name: Pytest, Sphinx Docs and Release
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  pytest-simple-with-coverage:
+    uses: repowerednl/.github/.github/workflows/python-test-coverage-simple.yml@REP-3986-Create-reusable-workflow-for-publishing-python-package
+    permissions:
+      pull-requests: write
+      contents: write
+      actions: read
+    strategy:
+      matrix:
+        # Make sure that the configured python versions are available here.
+        # These versions are cached on the runner; otherwise setting up python is too slow for the CI
+        # https://github.com/actions/runner-images/blob/main/images/ubuntu/toolsets/toolset-2004.json#L4
+        python_version: [ "3.11.2" ]
+        poetry_version: [ "1.8.4" ]
+    with:
+      python_version: ${{ matrix.python_version }}
+      poetry_version: ${{ matrix.poetry_version }}
+      # The poetry cached installation is in '/home/runner/.local/' and the './.venv' is for the poetry packages
+      # when configuring a working directory, make sure the cached paths are also up-to-date
+      file_paths_to_cache: |
+        .venv
+        /home/runner/.local/
+      # working_directory: # Optional, defaults to '.'
+    secrets:
+      private_pypi_url: ${{ secrets.PRIVATE_PYPI_URL }}
+      private_pypi_user: ${{ secrets.PRIVATE_PYPI_USER }}
+      private_pypi_password: ${{ secrets.PRIVATE_PYPI_PASSWORD }}
+
+  deploy-sphinx-documentation:
+    if: ${{ github.head_ref || github.ref_name }} == 'main'
+    uses: repowerednl/.github/.github/workflows/deploy-sphinx-documentation.yml@REP-3986-Create-reusable-workflow-for-publishing-python-package
+    with:
+      python_version: "3.11.2"
+      poetry_version: "1.8.4"
+      # The poetry cached installation is in '/home/runner/.local/' and the './.venv' is for the poetry packages
+      # when configuring a working directory, make sure the cached paths are also up-to-date
+      file_paths_to_cache: |
+        .venv
+        /home/runner/.local/
+      docs_target: /home/repowered/docs/<package-name> # ------------- This needs to be manually configured! -----------------------
+    secrets:
+      private_pypi_url: ${{ secrets.PRIVATE_PYPI_URL }}
+      private_pypi_user: ${{ secrets.PRIVATE_PYPI_USER }}
+      private_pypi_password: ${{ secrets.PRIVATE_PYPI_PASSWORD }}
+      docs_ssh_private_key: ${{ secrets.DOCS_SSH_PRIVATE_KEY }}
+
+  release:
+    if: ${{ github.head_ref || github.ref_name }} == 'main'
+    uses: repowerednl/.github/.github/workflows/deploy-sphinx-documentation.yml@REP-3986-Create-reusable-workflow-for-publishing-python-package
+    with:
+      python_version: "3.11.2"
+      poetry_version: "1.8.4"
+      # The poetry cached installation is in '/home/runner/.local/' and the './.venv' is for the poetry packages
+      # when configuring a working directory, make sure the cached paths are also up-to-date
+      file_paths_to_cache: |
+        .venv
+        /home/runner/.local/
+    secrets:
+      private_pypi_url: ${{ secrets.PRIVATE_PYPI_URL }}
+      private_pypi_user: ${{ secrets.PRIVATE_PYPI_USER }}
+      private_pypi_password: ${{ secrets.PRIVATE_PYPI_PASSWORD }}


### PR DESCRIPTION
#### semver tag:
- #minor

### Summary
Created reusable workflows for simple pytesting, deploying sphinx docs and releasing a python packages together with a template that combines the three reusable workflows

Also tweaked the original/'advanced' pytesting workflow by removing the 'save-cache-once' step as it is already present in the composite action and removed the reference to a non-existing branch

### Jira ticket
- https://repowerednl.atlassian.net/browse/REP-986

- [ ]  Still needs to be tested and documented in `workflow-tests` repository but that is only possible after this initial merge to main