### PR TITLE
Use tagged image instead of latest

### DIFF
--- a/.github/workflows/deploy-verify-kubernetes.yml
+++ b/.github/workflows/deploy-verify-kubernetes.yml
@@ -39,12 +39,11 @@ jobs:
       - name: Deploy ${{ matrix.container_name }}
         run: | 
           if [[ "${{ github.ref_name }}" == "main" ]]; then
-            echo "Production deployment. Restarting the deployment with the updated 'latest' tag"
-            kubectl rollout restart deployment ${{ matrix.container_name }}-deployment
+            echo "Production deployment. Release image is ${{ inputs.docker_image_tag }} which is now also set to 'latest'
           else
             echo "Non-production deployment. Updating image to ${{ inputs.docker_image_tag }} and restarting"
-            kubectl set image deployment/${{ matrix.container_name }}-deployment ${{ matrix.container_name }}=${{ inputs.docker_image_tag }}
           fi
+          kubectl set image deployment/${{ matrix.container_name }}-deployment ${{ matrix.container_name }}=${{ inputs.docker_image_tag }}
 
       - name: Verify ${{matrix.container_name}} deployment
         run: kubectl rollout status deployment/${{matrix.container_name}}-deployment


### PR DESCRIPTION
#### semver tag:
- #patch

### Summary
I changed the pull policy to 'IfNotPresent' (https://github.com/repowerednl/repower-infra/pull/78) due to enormous resources it needs upon deployment (or during cluster upgrades). Therefore the tagged version needs to be used instead of the latest. 

### Jira ticket
- https://repowerednl.atlassian.net/browse/IN-95