### PR TITLE
Extract versioned tag for deployment & fix prerelease bug

### DIFF
--- a/.github/workflows/deploy-verify-kubernetes.yml
+++ b/.github/workflows/deploy-verify-kubernetes.yml
@@ -39,11 +39,12 @@ jobs:
       - name: Deploy ${{ matrix.container_name }}
         run: | 
           if [[ "${{ github.ref_name }}" == "main" ]]; then
-            echo "Production deployment. Release image is ${{ inputs.docker_image_tag }} which is now also set to 'latest'"
+            echo "Production deployment. Release image tags are: ${{ inputs.docker_image_tag }}."
+            VERSIONED_TAG=$(echo "${{ inputs.docker_image_tag }}" | cut -d',' -f1)
           else
             echo "Non-production deployment. Updating image to ${{ inputs.docker_image_tag }} and restarting"
           fi
-          kubectl set image deployment/${{ matrix.container_name }}-deployment ${{ matrix.container_name }}=${{ inputs.docker_image_tag }}
+          kubectl set image deployment/${{ matrix.container_name }}-deployment ${{ matrix.container_name }}=$VERSIONED_TAG
 
       - name: Verify ${{matrix.container_name}} deployment
         run: kubectl rollout status deployment/${{matrix.container_name}}-deployment

--- a/.github/workflows/generate-github-tag.yml
+++ b/.github/workflows/generate-github-tag.yml
@@ -33,8 +33,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true
-          RELEASE_BRANCHES: dev
+          RELEASE_BRANCHES: main
           DEFAULT_BUMP: patch
-          PRERELEASE: ${{ !contains(github.event.workflow_run.head_branch, 'dev') 
-            || (contains(github.event.workflow_run.pull_requests[0].base.ref, 'main') && contains(github.event.workflow_run.head_commit.message, '[deploy]')) 
-            || (contains(github.event.workflow_run.pull_requests[0].base.ref, 'main') && github.event.label.name == 'deploy') }}
+          PRERELEASE: ${{ !contains(github.event.workflow_run.head_branch, 'dev')
+            || !contains(github.event.workflow_run.head_branch, 'main')
+            || contains(github.event.workflow_run.head_commit.message, '[deploy]')
+            || github.event.label.name == 'deploy' }}


### PR DESCRIPTION
## Version bump 
#patch: fix kube deployment

## Summary
- Forgot that for a production deployment, the image is tagged twice (which we can of course not use in deployments)
- Saw that an if-case was missing for the main branch and the release branch was wrong


