### PR TITLE
Release note generator

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,61 @@
+name-template: "$REPOSITORY_NAME $NEXT_PATCH_VERSION"
+tag-template: "v$NEXT_PATCH_VERSION"
+
+exclude-labels:
+  - "ignore-for-release"
+  - "skip-changelog"
+  - "meta"
+  - "chore"
+
+exclude-contributors:
+  - "octocat"
+  - "dependabot[bot]"
+  - "renovate[bot]"
+
+categories:
+  - title: "🛠 Breaking Changes"
+    labels:
+      - "Semver-Major"
+      - "breaking-change"
+  - title: "🎉 Exciting New Features"
+    labels:
+      - "Semver-Minor"
+      - "feature"
+      - "enhancement"
+  - title: "🐛 Bug Fixes"
+    labels:
+      - "Semver-Patch"
+      - "bug"
+      - "fix"
+  - title: "📄 Documentation"
+    labels:
+      - "docs"
+      - "documentation"
+  - title: "🧹 Maintenance & Refactoring"
+    labels:
+      - "refactor"
+      - "code-cleanup"
+      - "maintenance"
+  - title: "🧪 Tests"
+    labels:
+      - "test"
+      - "testing"
+  - title: "📦 Dependency Updates"
+    labels:
+      - "dependencies"
+      - "build"
+      - "ci"
+  - title: "📂 Uncategorized"
+    labels:
+      - "*"
+
+change-template: "- $TITLE (#$NUMBER) by @$AUTHOR"
+
+template: |
+  ### What's Changed
+
+  $CHANGES
+
+  ---
+
+  🛠 This release was automatically generated using [Release Drafter](https://github.com/release-drafter/release-drafter).

--- a/.github/workflows/release-notes-generator.yml
+++ b/.github/workflows/release-notes-generator.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   release:
-    if: ${{ github.event.pull_request.base.ref == 'main' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout tagged commit

--- a/.github/workflows/release-notes-generator.yml
+++ b/.github/workflows/release-notes-generator.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   release:
-    if: contains(${{ github.ref }}, "main")
+    if: ${{ github.event.pull_request.base.ref == 'main' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout tagged commit

--- a/.github/workflows/release-notes-generator.yml
+++ b/.github/workflows/release-notes-generator.yml
@@ -1,0 +1,35 @@
+name: Create Release after Deploy to Main
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: "The Semantic Versioning GitHub tag used for version control"
+        required: true
+        type: string
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Ensure workflow is running on main
+        run: |
+            if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
+                echo "Running on branch: ${{ github.ref }}"
+                echo "This workflow can only be run on the main branch."
+                exit 1
+            fi
+      - name: Checkout tagged commit
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate GitHub Release
+        uses: release-drafter/release-drafter@v5
+        with:
+          tag: ${{ inputs.tag }}
+          name: ${{ github.event.repository.name }} ${{ inputs.tag }}
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-notes-generator.yml
+++ b/.github/workflows/release-notes-generator.yml
@@ -10,23 +10,16 @@ on:
 
 jobs:
   release:
+    if: contains(${{ github.ref }}, "main")
     runs-on: ubuntu-latest
-
     steps:
-      - name: Ensure workflow is running on main
-        run: |
-            if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
-                echo "Running on branch: ${{ github.ref }}"
-                echo "This workflow can only be run on the main branch."
-                exit 1
-            fi
       - name: Checkout tagged commit
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Generate GitHub Release
-        uses: release-drafter/release-drafter@v5
+        uses: release-drafter/release-drafter@v6
         with:
           tag: ${{ inputs.tag }}
           name: ${{ github.event.repository.name }} ${{ inputs.tag }}

--- a/workflow-templates/tag-docker-kube.yml
+++ b/workflow-templates/tag-docker-kube.yml
@@ -24,7 +24,7 @@ jobs:
   # This job will only run if ran from the main branch
   create-release:
     needs: tag
-    uses: repowerednl/.github/.github/workflows/release-notes-generator.yml@release-notes-generator
+    uses: repowerednl/.github/.github/workflows/release-notes-generator.yml@main
     with:
       tag: ${{ needs.tag.outputs.tag }}
 

--- a/workflow-templates/tag-docker-kube.yml
+++ b/workflow-templates/tag-docker-kube.yml
@@ -24,7 +24,7 @@ jobs:
   # This job will only run if ran from the main branch
   create-release:
     needs: tag
-    uses: repowerednl/.github/.github/workflows/release-notes-generator.yml@main
+    uses: repowerednl/.github/.github/workflows/release-notes-generator.yml@release-notes-generator
     with:
       tag: ${{ needs.tag.outputs.tag }}
 

--- a/workflow-templates/tag-docker-kube.yml
+++ b/workflow-templates/tag-docker-kube.yml
@@ -21,6 +21,13 @@ jobs:
       contents: write
     uses: repowerednl/.github/.github/workflows/generate-github-tag.yml@main
 
+  # This job will only run if ran from the main branch
+  create-release:
+    needs: tag
+    uses: repowerednl/.github/.github/workflows/release-notes-generator.yml@main
+    with:
+      tag: ${{ needs.tag.outputs.tag }}
+
   # Only for the front-end; delete this job if you don't have a 'package.json'
   # If you do, add bump to the 'needs' section for docker -> needs: [tag, bump]
   bump:

--- a/workflow-templates/tag-docker-ssh.yml
+++ b/workflow-templates/tag-docker-ssh.yml
@@ -21,6 +21,12 @@ jobs:
       contents: write
     uses: repowerednl/.github/.github/workflows/generate-github-tag.yml@main
 
+  # This job will only run if ran from the main branch
+  create-release:
+    needs: tag
+    uses: repowerednl/.github/.github/workflows/release-notes-generator.yml@main
+    with:
+      tag: ${{ needs.tag.outputs.tag }}
 
   # Only for the front-end; delete this job if you don't have a 'package.json'
   # If you do, add bump to the 'needs' section -> needs: [tag, bump]


### PR DESCRIPTION
## Version bump 
#minor

## Summary
- Added the logic (`release-notes-generator`) for creating automated release notes when tag-docker-kube and tag-docker-ssh are run.
- The release is generated as a **draft**
- The release body follows the template in `release-drafter.yml`
- The release notes vary depending on the LABEL that the PRs are assigned with (feature, bug, documentation, etc.)
- Should only run when in 'main' branch

### Jira ticket
https://repowerednl.atlassian.net/browse/IN-100

### TODO
- [x] Test this on other repos


