### PR TITLE
Initial Helm deployment workflow version

### DIFF
--- a/.github/workflows/deploy-helm-kubernetes.yml
+++ b/.github/workflows/deploy-helm-kubernetes.yml
@@ -67,9 +67,6 @@ jobs:
           # Check if current Helm version matches the target version
           if [[ "$HELM_VERSION" == ${{ env.version }} && "$VALUES_UPDATED" == false ]]; then
             echo "Setting the new image: ${{ inputs.docker_image_tag }}" 
-            DRY_RUN=$(helm upgrade ${{ env.name }} oci://ghcr.io/repowerednl/helm-charts/deployment \
-              --namespace ${{ env.name }} --reuse-values --set image=${{ inputs.docker_image_tag }} --dry-run)
-            echo "The dry-run was successful. Deploying now"
             helm upgrade ${{ env.name }} oci://ghcr.io/repowerednl/helm-charts/deployment \
               --namespace ${{ env.name }} --reuse-values --set image=${{ inputs.docker_image_tag }}
           else
@@ -83,12 +80,7 @@ jobs:
             # Login to repowered container registry
             echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u repowerednl --password-stdin
 
-            # Perform dry-run installation for the deployment
-            DRY_RUN=$(helm install ${{ env.name }} oci://ghcr.io/repowerednl/helm-charts/deployment \
-              --version ${{ env.version }} --namespace ${{ env.name }} $CREATE_NAMESPACE_COMMAND \
-              --values ${{ matrix.file }} --dry-run)
-            echo "The dry-run for the new deployment in namespace ${{ env.name }} was successful. Deploying now"
-            helm install ${{ env.name }} oci://ghcr.io/repowerednl/helm-charts/deployment \
+            helm upgrade --install ${{ env.name }} oci://ghcr.io/repowerednl/helm-charts/deployment \
               --version ${{ env.version }} --namespace ${{ env.name }} $CREATE_NAMESPACE_COMMAND \
               --values ${{ matrix.file }}
           fi

--- a/.github/workflows/deploy-helm-kubernetes.yml
+++ b/.github/workflows/deploy-helm-kubernetes.yml
@@ -1,0 +1,95 @@
+name: Deploy the docker image on Kubernetes and verify the deployment
+
+on:
+  workflow_call:
+    inputs:
+      # Required
+      deployment_name-values_file:
+        description: "The name for the deployment (when empty it uses the repo name) and the corresponding helm values filename (defaults to 'values.yml)"
+        required: false
+        default: [{"name": "", "file": "values.yml"}]
+      docker_image_tag:
+        type: string
+        required: true
+      environment:
+        type: string
+        required: true
+      helm_deployment_version:
+        type: string
+        required: true
+    secrets:
+      digital_ocean_access_token:
+        required: true
+
+jobs:
+  deploy-helm:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    strategy:
+      matrix:
+        include: ${{ fromJson(inputs.deployment_name-values_file) }}
+    permissions:
+      packages: read
+      contents: read
+    steps:
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.digital_ocean_access_token }}
+
+      - name: Save DigitalOcean kubeconfig with short-lived credentials
+        env:
+          expiry-seconds: ${{ vars.KUBE_CRED_EXPIRY_SECOND || 300 }}
+        run: doctl kubernetes cluster kubeconfig save --expiry-seconds ${{ env.expiry-seconds }} dev-cluster
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4.3.0
+
+      - name: Checkout ${{ github.repository }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Helm Deployment to Kubernetes
+        env:
+          name: ${{ matrix.name || github.event.repository.name }}
+          version: ${{ inputs.helm_deployment_version }}
+        run: |
+          # Get the current deployed Helm version
+          HELM_VERSION=$(helm list -n ${{ env.name }} -o json | jq -r '.[0].app_version')
+
+          # Check if the deployment values have changed
+          VALUES_UPDATED=false
+          git diff --name-only HEAD~1 | grep -q ${{ matrix.file }} && VALUES_UPDATED=true
+
+          # Check if current Helm version matches the target version
+          if [[ "$HELM_VERSION" == ${{ env.version }} && "$VALUES_UPDATED" == false ]]; then
+            echo "Setting the new image: ${{ inputs.docker_image_tag }}" 
+            DRY_RUN=$(helm upgrade ${{ env.name }} oci://ghcr.io/repowerednl/helm-charts/deployment \
+              --namespace ${{ env.name }} --reuse-values --set image=${{ inputs.docker_image_tag }} --dry-run)
+            echo "The dry-run was successful. Deploying now"
+            helm upgrade ${{ env.name }} oci://ghcr.io/repowerednl/helm-charts/deployment \
+              --namespace ${{ env.name }} --reuse-values --set image=${{ inputs.docker_image_tag }}
+          else
+            # Set the namespace creation flag if it's an initial deployment
+            if [[ "$HELM_VERSION" == "null" ]]; then
+              CREATE_NAMESPACE_COMMAND="--create-namespace"
+            else
+              CREATE_NAMESPACE_COMMAND=""
+            fi
+
+            # Login to repowered container registry
+            echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u repowerednl --password-stdin
+
+            # Perform dry-run installation for the deployment
+            DRY_RUN=$(helm install ${{ env.name }} oci://ghcr.io/repowerednl/helm-charts/deployment \
+              --version ${{ env.version }} --namespace ${{ env.name }} $CREATE_NAMESPACE_COMMAND \
+              --values ${{ matrix.file }} --dry-run)
+            echo "The dry-run for the new deployment in namespace ${{ env.name }} was successful. Deploying now"
+            helm install ${{ env.name }} oci://ghcr.io/repowerednl/helm-charts/deployment \
+              --version ${{ env.version }} --namespace ${{ env.name }} $CREATE_NAMESPACE_COMMAND \
+              --values ${{ matrix.file }}
+          fi
+          # Output deployment status to the GitHub summary
+          echo ':chart: Helm Status Output' >> $GITHUB_STEP_SUMMARY
+          helm status ${{ env.name }} -n ${{ env.name }} >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-helm-kubernetes.yml
+++ b/.github/workflows/deploy-helm-kubernetes.yml
@@ -4,10 +4,6 @@ on:
   workflow_call:
     inputs:
       # Required
-      deployment_name-values_file:
-        description: "The name for the deployment (when empty it uses the repo name) and the corresponding helm values filename (defaults to 'values.yml)"
-        required: false
-        default: [{"name": "", "file": "values.yml"}]
       docker_image_tag:
         type: string
         required: true
@@ -17,6 +13,12 @@ on:
       helm_deployment_version:
         type: string
         required: true
+      # Optional
+      deployment_name-values_file:
+        type: string
+        description: "The name for the deployment (when empty it uses the repo name) and the corresponding helm values filename (defaults to 'values.yml)"
+        required: false
+        default: "[{\'name\': \'\', \'file\': \'values.yml\'}]"
     secrets:
       digital_ocean_access_token:
         required: true

--- a/.github/workflows/deploy-helm-kubernetes.yml
+++ b/.github/workflows/deploy-helm-kubernetes.yml
@@ -1,4 +1,4 @@
-name: Deploy the docker image on Kubernetes and verify the deployment
+name: Do a Helm deployment
 
 on:
   workflow_call:

--- a/.github/workflows/deploy-helm-kubernetes.yml
+++ b/.github/workflows/deploy-helm-kubernetes.yml
@@ -14,6 +14,9 @@ on:
         type: string
         required: true
       # Optional
+      namespace:
+        type: string
+        required: false
       deployment_name-values_file:
         type: string
         description: "The name for the deployment (when empty it uses the repo name) and the corresponding helm values filename (defaults to 'values.yml)"
@@ -57,6 +60,7 @@ jobs:
         env:
           name: ${{ matrix.name || github.event.repository.name }}
           version: ${{ inputs.helm_deployment_version }}
+          ns: ${{ inputs.namespace || github.event.repository.name }}
         run: |
           # Get the current deployed Helm version
           HELM_VERSION=$(helm list -n ${{ env.name }} -o json | jq -r '.[0].app_version')
@@ -71,7 +75,7 @@ jobs:
           if [[ "$HELM_VERSION" == ${{ env.version }} && "$VALUES_UPDATED" == false ]]; then
             echo "Setting the new image: ${{ inputs.docker_image_tag }}"
             helm upgrade ${{ env.name }} oci://ghcr.io/repowerednl/helm-charts/deployment \
-              --namespace ${{ env.name }} --reuse-values --set image=${{ inputs.docker_image_tag }}
+              --namespace ${{ env.ns }} --reuse-values --set image=${{ inputs.docker_image_tag }}
           else
             # Set the namespace creation flag if it's an initial deployment
             if [[ "$HELM_VERSION" == "null" ]]; then
@@ -84,7 +88,7 @@ jobs:
             echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u repowerednl --password-stdin
             echo "Upgrading or installing the deployment"
             helm upgrade --install ${{ env.name }} oci://ghcr.io/repowerednl/helm-charts/deployment \
-              --version ${{ env.version }} --namespace ${{ env.name }} $CREATE_NAMESPACE_COMMAND \
+              --version ${{ env.version }} --namespace ${{ env.ns }} $CREATE_NAMESPACE_COMMAND \
               --values ${{ matrix.file }}
           fi
 
@@ -92,10 +96,11 @@ jobs:
         env:
           name: ${{ matrix.name || github.event.repository.name }}
           version: ${{ inputs.helm_deployment_version }}
+          ns: ${{ inputs.namespace || github.event.repository.name }}
         run: |         
           echo "<h2> :chart: Helm Status Output </h2>" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          helm status ${{ env.name }} -n ${{ env.name }} >> $GITHUB_STEP_SUMMARY
+          helm status ${{ env.name }} -n ${{ env.ns }} >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Image used: ${{ inputs.docker_image_tag }} " >> $GITHUB_STEP_SUMMARY
           if [ ${{ steps.helm-deployment.outputs.helm_version }} == "null"]; then

--- a/.github/workflows/deploy-helm-kubernetes.yml
+++ b/.github/workflows/deploy-helm-kubernetes.yml
@@ -50,23 +50,26 @@ jobs:
       - name: Checkout ${{ github.repository }}
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          fetch-depth: 2
 
       - name: Helm Deployment to Kubernetes
+        id: helm-deployment
         env:
           name: ${{ matrix.name || github.event.repository.name }}
           version: ${{ inputs.helm_deployment_version }}
         run: |
           # Get the current deployed Helm version
           HELM_VERSION=$(helm list -n ${{ env.name }} -o json | jq -r '.[0].app_version')
+          echo "helm_version=$HELM_VERSION" >> $GITHUB_OUTPUT
 
           # Check if the deployment values have changed
           VALUES_UPDATED=false
           git diff --name-only HEAD~1 | grep -q ${{ matrix.file }} && VALUES_UPDATED=true
+          echo "values_updated=$VALUES_UPDATED" >> $GITHUB_OUTPUT
 
           # Check if current Helm version matches the target version
           if [[ "$HELM_VERSION" == ${{ env.version }} && "$VALUES_UPDATED" == false ]]; then
-            echo "Setting the new image: ${{ inputs.docker_image_tag }}" 
+            echo "Setting the new image: ${{ inputs.docker_image_tag }}"
             helm upgrade ${{ env.name }} oci://ghcr.io/repowerednl/helm-charts/deployment \
               --namespace ${{ env.name }} --reuse-values --set image=${{ inputs.docker_image_tag }}
           else
@@ -79,11 +82,26 @@ jobs:
 
             # Login to repowered container registry
             echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u repowerednl --password-stdin
-
+            echo "Upgrading or installing the deployment"
             helm upgrade --install ${{ env.name }} oci://ghcr.io/repowerednl/helm-charts/deployment \
               --version ${{ env.version }} --namespace ${{ env.name }} $CREATE_NAMESPACE_COMMAND \
               --values ${{ matrix.file }}
           fi
-          # Output deployment status to the GitHub summary
-          echo ':chart: Helm Status Output' >> $GITHUB_STEP_SUMMARY
+
+      - name: Helm deployment status as summary
+        env:
+          name: ${{ matrix.name || github.event.repository.name }}
+          version: ${{ inputs.helm_deployment_version }}
+        run: |         
+          echo "<h2> :chart: Helm Status Output </h2>" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
           helm status ${{ env.name }} -n ${{ env.name }} >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Image used: ${{ inputs.docker_image_tag }} " >> $GITHUB_STEP_SUMMARY
+          if [ ${{ steps.helm-deployment.outputs.helm_version }} == "null"]; then
+            echo ":new: This was an initial deployment" >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "Updated values? ${{ steps.helm-deployment.outputs.values_updated }} " >> $GITHUB_STEP_SUMMARY
+          if [ ${{ steps.helm-deployment.outputs.helm_version }} != "${{ env.version }}" ]; then
+            echo "New Helm version used: ${{ env.version }}" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/workflow-templates/tag-docker-helm-kube.properties.json
+++ b/workflow-templates/tag-docker-helm-kube.properties.json
@@ -1,0 +1,10 @@
+{
+    "name": "Tag, docker, Helm chart and Kubernetes deploy",
+    "description": "Create and publish a SemVer GitHub Tag, Build the docker image(s) for the hub, use the custom Helm deployment chart with repository values and deploy that to Kubernetes",
+    "iconName": "octicon container",
+    "categories": ["Repowered"],
+    "filePatterns": [
+        "(.*\\/)?Dockerfile(\\.{1}[^.].*)?",
+        "^[a-zA-Z0-9_-]+_values\\.(yml|yaml)$"
+    ]
+}

--- a/workflow-templates/tag-docker-helm-kube.yml
+++ b/workflow-templates/tag-docker-helm-kube.yml
@@ -67,7 +67,7 @@ jobs:
       # docker_secret_6:
 
 #   TODO(REP-2945): Move this step to the repository infra
-#   Should only be active for repower-django (add job to 'needs' in deploy-verify)
+#   Should only be active for apps with a database (add job to 'needs' in deploy-helm)
     run-migrations:
       uses: repowerednl/.github/.github/workflows/run-kube-migration.yml@main
       needs: [tag, github-environment]

--- a/workflow-templates/tag-docker-helm-kube.yml
+++ b/workflow-templates/tag-docker-helm-kube.yml
@@ -1,0 +1,96 @@
+name: GitHub Tag, Docker publish build, Kubernetes Deploy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_run:
+    workflows:
+!      - # The actual name of your TEST workflow (example: Run Yarn commands (install, check-updates, lint, prettier, test with coverage and/or build with publish) and run the Sonar Analysis)
+    types:
+      - completed
+  pull_request:
+    types:
+      - labeled
+
+run-name: Deploy branch ${{ github.event.workflow_run.head_branch || 'main' }} by @${{ github.actor }}
+
+jobs:
+  tag:
+    permissions:
+      contents: write
+    uses: repowerednl/.github/.github/workflows/generate-github-tag.yml@main
+
+  # This job will only run if ran from the main branch
+  create-release:
+    needs: tag
+    uses: repowerednl/.github/.github/workflows/release-notes-generator.yml@main
+    with:
+      tag: ${{ needs.tag.outputs.tag }}
+
+  # Only for the front-end; delete this job if you don't have a 'package.json'
+  # If you do, add bump to the 'needs' section for docker -> needs: [tag, bump]
+  bump:
+    permissions:
+      contents: write
+    uses: repowerednl/.github/.github/workflows/bump-package-json.yml@main
+    needs: tag
+    with:
+      tag: ${{ needs.tag.outputs.tag }}
+
+  github-environment:
+    permissions:
+      pull-requests: read
+    uses: repowerednl/.github/.github/workflows/determine-environment.yml@main
+
+  # Repeat the steps docker + deploy-helm if there are multiple Dockerfiles/Helm values
+
+  docker:
+    uses: repowerednl/.github/.github/workflows/docker-build-and-push.yml@main
+    needs: [ tag, github-environment ]
+    with:
+      tag: ${{ needs.tag.outputs.tag }}
+      docker_hub_username: ${{ vars.DOCKER_HUB_USERNAME }}
+      environment: ${{ needs.github-environment.outputs.environment }}
+      # dockerfile_name: # Optional, defaults to 'Dockerfile'
+      # build_argument_one: # Optional, no default; from GitHub Variables
+      # build_argument_two: # Optional, no default; from GitHub Variables
+      # build_argument_three: # Optional, no default; from GitHub Variables
+    secrets:
+      docker_hub_access_token: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      # Optional (Current maximum of secrets that can be set =  6 secrets. Can be expanded)
+      # docker_secret_1:
+      # docker_secret_2:
+      # docker_secret_3:
+      # docker_secret_4:
+      # docker_secret_5:
+      # docker_secret_6:
+
+#   TODO(REP-2945): Move this step to the repository infra
+#   Should only be active for repower-django (add job to 'needs' in deploy-verify)
+    run-migrations:
+      uses: repowerednl/.github/.github/workflows/run-kube-migration.yml@main
+      needs: [tag, github-environment]
+      with:
+        tag: ${{ needs.tag.outputs.tag }}
+        environment: ${{ needs.github-environment.outputs.environment }}
+      secrets:
+        digital_ocean_access_token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+        infisical_client_id: ${{ secrets.INFISICAL_CLIENT_ID }}
+        infisical_client_client_secret: ${{ secrets.INFISICAL_CLIENT_SECRET }}
+        infisical_client_project_id: ${{ secrets.INFISICAL_PROJECT_ID }}
+
+  deploy-helm:
+    uses: repowerednl/.github/.github/workflows/deploy-helm-kubernetes.yml@main
+    needs: [ docker ]
+    with:
+      docker_image_tag: ${{ needs.docker.outputs.image_tag }}
+      environment: ${{ needs.docker.outputs.environment }}
+      helm_deployment_version: ${{ vars.HELM_DEPLOYMENT_VERSION }} # i.e. the chart's version that should be used. See https://github.com/repowerednl/repower-infra/pkgs/container/helm-charts%2Fdeployment
+      # If there are multiple deployments for a single docker image, the deployment names and values files can be specified here
+      # Example:
+      # Dockerfile 'hello-world' is responsible for the following deployments: foo, bar
+      # the corresponding deployment_name-values_file object is: "[{"name": "foo", "file": "foo_values.yml"}, {"name": "bar", "file": "bar_values.yml"}]"
+      # deployment_name-values_file: # A JSON list objects string; defaults to "[{"name": "", "file": "values.yml"}]" where name results in the repo name
+    secrets:
+      digital_ocean_access_token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}

--- a/workflow-templates/tag-docker-helm-kube.yml
+++ b/workflow-templates/tag-docker-helm-kube.yml
@@ -1,4 +1,4 @@
-name: GitHub Tag, Docker publish build, Kubernetes Deploy
+name: GitHub Tag, Docker publish build, Helm deployment
 
 on:
   push:
@@ -13,7 +13,7 @@ on:
     types:
       - labeled
 
-run-name: Deploy branch ${{ github.event.workflow_run.head_branch || 'main' }} by @${{ github.actor }}
+run-name: Deploy branch ${{ github.event.workflow_run.head_branch || github.head_ref || 'main' }} by @${{ github.actor }}
 
 jobs:
   tag:

--- a/workflow-templates/tag-docker-helm-kube.yml
+++ b/workflow-templates/tag-docker-helm-kube.yml
@@ -87,10 +87,11 @@ jobs:
       docker_image_tag: ${{ needs.docker.outputs.image_tag }}
       environment: ${{ needs.docker.outputs.environment }}
       helm_deployment_version: ${{ vars.HELM_DEPLOYMENT_VERSION }} # i.e. the chart's version that should be used. See https://github.com/repowerednl/repower-infra/pkgs/container/helm-charts%2Fdeployment
-      # If there are multiple deployments for a single docker image, the deployment names and values files can be specified here
-      # Example:
-      # Dockerfile 'hello-world' is responsible for the following deployments: foo, bar
-      # the corresponding deployment_name-values_file object is: "[{"name": "foo", "file": "foo_values.yml"}, {"name": "bar", "file": "bar_values.yml"}]"
+      # namespace: # Optional; defaults to the repository name if not set
+      #  If there are multiple deployments for a single docker image, the deployment names and values files can be specified here
+      #  Example:
+      #  Dockerfile 'hello-world' is responsible for the following deployments: foo, bar
+      #  the corresponding deployment_name-values_file object is: "[{"name": "foo", "file": "foo_values.yml"}, {"name": "bar", "file": "bar_values.yml"}]"
       # deployment_name-values_file: # A JSON list objects string; defaults to "[{"name": "", "file": "values.yml"}]" where name results in the repo name
     secrets:
       digital_ocean_access_token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}

--- a/workflow-templates/tag-docker-kube.yml
+++ b/workflow-templates/tag-docker-kube.yml
@@ -67,7 +67,7 @@ jobs:
       # docker_secret_6:
 
 #   TODO(REP-2945): Move this step to the repository infra
-#   Should only be active for repower-django (add job to 'needs' in deploy-verify)
+#   Should only be active for apps with a database (add job to 'needs' in deploy-verify)
     run-migrations:
       uses: repowerednl/.github/.github/workflows/run-kube-migration.yml@main
       needs: [tag, github-environment]


### PR DESCRIPTION
## Version bump 
#minor: Add the helm deployment reusable workflow and workflow template

## Summary
The `deploy-helm-kubernetes` workflow has been added. It has three flavour/functions:
- Set the newly build docker image in the helm deployment (same as before; now just for helm)
- Creates a new deployment when:
    - The `HELM_DEPLOYMENT_VERSION` has been changed in the action variable w.r.t. the cluster variant
    - The `[<name_>]values.yml|yaml` file has been changed in the branch

The template `tag-docker-helm-kube` is almost the same as `tag-docker-kube` but now uses the helm variant instead of the kubectl variant.

Also:
- The Helm deployment chart package is [here](https://github.com/repowerednl/repower-infra/pkgs/container/helm-charts%2Fdeployment)
- The complete 'values.yml' that Helm uses can be found [here](https://github.com/repowerednl/repower-infra/blob/dev/helm-charts/deployment/values.yaml). 
   - This file should be added to the repository. People who work on the code can also determine the deployment values (i.e. how many resources does it need for example). 
   - It works with only this in the values file:
  ```values.yml
  # Container image to deploy
  image: repowered/<repo-name>:latest
  ```

### Jira ticket
https://repowerednl.atlassian.net/browse/IN-193

## Checks
- [x] I have tested this. See workflow test PR: https://github.com/repowerednl/workflow-tests/pull/33 and [action run summary](https://github.com/repowerednl/workflow-tests/actions/runs/14979549275#summary-42080191270)

## TODO
- [x] A Helm (migration) job needs to be written and it's values (i.e alembic or django) should be added to the repository. Reference standard yml file for django: https://github.com/repowerednl/repower-django/blob/dev/migrations_job.yml
