### PR TITLE
Do auto version bump in a new PR

### DIFF
--- a/.github/workflows/bump-package-json.yml
+++ b/.github/workflows/bump-package-json.yml
@@ -34,14 +34,15 @@ jobs:
 
       - name: Bump Version
         run: |
-          VERSION=${{ inputs.tag }}
-          VERSION=${VERSION#v}  # Remove leading 'v' if present
+          VERSION="${{ inputs.tag }}"
+          VERSION="${VERSION#v}"  # Remove leading 'v' if present
           npm version "$VERSION" --no-git-tag-version
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -b bump-version-$VERSION
+          BRANCH="bump-version-$VERSION-$(date +%s)"
+          git checkout -b "$BRANCH"
           git add package.json package-lock.json
-          git commit -m "Automated version bump [skip-ci]"
+          git commit -m "Automated version bump to $VERSION [skip-ci]"
           git push origin HEAD
 
       - name: Create PR for version bump

--- a/.github/workflows/bump-package-json.yml
+++ b/.github/workflows/bump-package-json.yml
@@ -7,9 +7,15 @@ on:
         required: true
         type: string
         description: "The Semantic Versioning GitHub tag used for version control"
+      # Optional
+      node_version:
+        required: false
+        type: string
+        default: "20"
 
 jobs:
   update-package-json:
+    if: ${{ github.event.pull_request.head.ref == "main" }}
     continue-on-error: true
     runs-on: ubuntu-latest
     permissions:
@@ -21,30 +27,27 @@ jobs:
           fetch-depth: '0'
           ref: ${{ github.event.workflow_run.head_sha }}
 
-      - name: Automated Version Bump
-        uses: phips28/gh-action-bump-version@v11.0.7
-        id: version-bump
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup Node
+        uses: actions/setup-node@v4
         with:
-          major-wording: "#major"
-          minor-wording: "#minor"
-          patch-wording: "#patch"
-          skip-tag:  "true" # Already done in another (reusable) workflow
-          target-branch: 'dev'
-          commit-message: "Auto bump version of package.json to {{version}} [skip ci]"
+          node-version: ${{ inputs.node_version }}
 
-      - name: Equality of Version Bump and Git Tag
+      - name: Bump Version
         run: |
-          # Strip leading 'v' and pre-release info (if any)
-          TAG="${{ inputs.tag }}"
-          TAG="${TAG#v}"; TAG="${TAG%%-*}"
-          if [ "${{ steps.version-bump.outputs.newTag }}" != "$TAG" ]; then
-            echo ":x: Version bump tag and whole GitHub tag do not match!" >> $GITHUB_STEP_SUMMARY
-            echo "Version bump tag: ${{ steps.version-bump.outputs.newTag }}" >> $GITHUB_STEP_SUMMARY
-            echo "GitHub pushed tag: ${{ inputs.tag }} so whole version: $TAG" >> $GITHUB_STEP_SUMMARY
-            echo "Please contact DevOps for this error " >> $GITHUB_STEP_SUMMARY
-          else
-            echo ":white_check_mark: Version bump tag and whole GitHub tag match: ${{ inputs.tag }}." >> $GITHUB_STEP_SUMMARY
-          fi
+          VERSION=${{ inputs.tag }}
+          VERSION=${VERSION#v}  # Remove leading 'v' if present
+          npm version "$VERSION" --no-git-tag-version
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b bump-version-$VERSION
+          git add package.json package-lock.json
+          git commit -m "Automated version bump [skip-ci]"
+          git push origin HEAD
 
+      - name: Create PR for version bump
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: "Release version bump: ${{ inputs.tag }}"
+          body: "Automated version bump [skip-ci]"
+          base: dev

--- a/.github/workflows/bump-package-json.yml
+++ b/.github/workflows/bump-package-json.yml
@@ -41,7 +41,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           BRANCH="bump-version-$VERSION-$(date +%s)"
           git checkout -b "$BRANCH"
-          git add package.json package-lock.json
+          git add package.json
           git commit -m "Automated version bump to $VERSION [skip-ci]"
           git push origin HEAD
 
@@ -51,4 +51,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           title: "Release version bump: ${{ inputs.tag }}"
           body: "Automated version bump [skip-ci]"
-          base: dev
+          base: main

--- a/.github/workflows/bump-package-json.yml
+++ b/.github/workflows/bump-package-json.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   update-package-json:
-    if: ${{ github.event.pull_request.head.ref == "main" }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     continue-on-error: true
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Version bump 
#patch: auto create a PR with the version bump

## Summary
Since it's really not possible to commit to `dev` safely because of the branch-protection rules, this only bumps the version for releases in a new PR to `dev`. It needs to be manually approved still

### Jira ticket
https://repowerednl.atlassian.net/browse/IN-171

