### PR TITLE
Add toJson+jq for commit msg in bash to handle backticks

### DIFF
--- a/.github/workflows/generate-github-tag.yml
+++ b/.github/workflows/generate-github-tag.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           # Extract context
           BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF##*/}}"
-          COMMIT_MSG='${{ github.event.workflow_run.head_commit.message || \'\' }}'
+          COMMIT_MSG=$(echo '${{ toJson(github.event.workflow_run.head_commit.message) }}' | jq -r .)
           LABEL="${{ github.event.label.name || '' }}"
           EVENT_NAME="${{ github.event_name }}"
           PR_HEAD="${{ github.event.pull_request.head.ref || '' }}"


### PR DESCRIPTION
## Version bump 
#patch: fix markdown (backtick) issue in commit message

## Summary
Add toJson + jq for commit msg in bash to handle backticks
See proof here: https://github.com/repowerednl/workflow-tests/actions/runs/15252489083

### Jira ticket
https://repowerednl.atlassian.net/browse/IN-224


