### PR TITLE
Add standard tag generation to release of pypi package and add release trigger

### DIFF
--- a/.github/workflows/release-pypi-package.yml
+++ b/.github/workflows/release-pypi-package.yml
@@ -50,7 +50,7 @@ jobs:
         private_pypi_password: ${{ secrets.private_pypi_password }}
         publish_pypi_url: ${{ secrets.publish_pypi_url }}
 
-    - name: Update version
+    - name: Update version to ${{ inputs.tag }}
       run: poetry version ${{ inputs.tag }}
 
     - name: Build and publish

--- a/.github/workflows/release-pypi-package.yml
+++ b/.github/workflows/release-pypi-package.yml
@@ -7,6 +7,9 @@ on:
         type: string
         required: true
       # Provided by caller workflow
+      tag:
+        type: string
+        required: true
       python_version:
         type: string
         required: true
@@ -48,7 +51,7 @@ jobs:
         publish_pypi_url: ${{ secrets.publish_pypi_url }}
 
     - name: Update version
-      run: poetry version ${{ github.event.release.tag_name }}
+      run: poetry version ${{ inputs.tag }}
 
     - name: Build and publish
       run: |

--- a/workflow-templates/test-sphinx-release-pypi.yml
+++ b/workflow-templates/test-sphinx-release-pypi.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  release:
-    types:
-      - created
   pull_request:
   workflow_dispatch:
 
@@ -51,7 +48,7 @@ jobs:
       tag: ${{ needs.tag.outputs.tag }}
 
   deploy-sphinx-documentation:
-    if: github.event_name == 'release'
+    needs: create-release
     uses: repowerednl/.github/.github/workflows/deploy-sphinx-documentation.yml@main
     with:
       python_version: "3.11.2"
@@ -69,8 +66,8 @@ jobs:
       docs_ssh_private_key: ${{ secrets.DOCS_SSH_PRIVATE_KEY }}
 
   release:
-    if: github.event_name == 'release'
-    uses: repowerednl/.github/.github/workflows/release-pypi-package.yml@add-tag-step-pypi-packages
+    needs: [tag, create-release]
+    uses: repowerednl/.github/.github/workflows/release-pypi-package.yml@main
     with:
       tag: ${{ needs.tag.outputs.tag }}
       python_version: "3.11.2"

--- a/workflow-templates/test-sphinx-release-pypi.yml
+++ b/workflow-templates/test-sphinx-release-pypi.yml
@@ -69,7 +69,6 @@ jobs:
       docs_ssh_private_key: ${{ secrets.DOCS_SSH_PRIVATE_KEY }}
 
   release:
-    needs: tag
     if: github.event_name == 'release'
     uses: repowerednl/.github/.github/workflows/release-pypi-package.yml@add-tag-step-pypi-packages
     with:

--- a/workflow-templates/test-sphinx-release-pypi.yml
+++ b/workflow-templates/test-sphinx-release-pypi.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  release:
+    types:
+      - created
   pull_request:
   workflow_dispatch:
 
@@ -35,9 +38,13 @@ jobs:
       private_pypi_user: ${{ secrets.PRIVATE_PYPI_USER }}
       private_pypi_password: ${{ secrets.PRIVATE_PYPI_PASSWORD }}
 
+  tag:
+    permissions:
+      contents: write
+    uses: repowerednl/.github/.github/workflows/generate-github-tag.yml@main
+
   deploy-sphinx-documentation:
-    needs: pytest-simple-with-coverage
-    if: contains('main', github.head_ref) || contains('main', github.ref_name)
+    if: github.event_name == 'release'
     uses: repowerednl/.github/.github/workflows/deploy-sphinx-documentation.yml@main
     with:
       python_version: "3.11.2"
@@ -55,10 +62,11 @@ jobs:
       docs_ssh_private_key: ${{ secrets.DOCS_SSH_PRIVATE_KEY }}
 
   release:
-    needs: pytest-simple-with-coverage
-    if: contains('main', github.head_ref) || contains('main', github.ref_name)
-    uses: repowerednl/.github/.github/workflows/release-pypi-package.yml@main
+    needs: tag
+    if: github.event_name == 'release'
+    uses: repowerednl/.github/.github/workflows/release-pypi-package.yml@add-tag-step-pypi-packages
     with:
+      tag: ${{ needs.tag.outputs.tag }}
       python_version: "3.11.2"
       poetry_version: "1.8.4"
       poetry_no_root: false

--- a/workflow-templates/test-sphinx-release-pypi.yml
+++ b/workflow-templates/test-sphinx-release-pypi.yml
@@ -43,6 +43,13 @@ jobs:
       contents: write
     uses: repowerednl/.github/.github/workflows/generate-github-tag.yml@main
 
+  # This job will only run if ran from the main branch
+  create-release:
+    needs: tag
+    uses: repowerednl/.github/.github/workflows/release-notes-generator.yml@main
+    with:
+      tag: ${{ needs.tag.outputs.tag }}
+
   deploy-sphinx-documentation:
     if: github.event_name == 'release'
     uses: repowerednl/.github/.github/workflows/deploy-sphinx-documentation.yml@main


### PR DESCRIPTION
## Version bump 
#minor: add tag to release of pypi package workflow

## Summary
It adds a tag to release workflow of a pypi package. Also the trigger for a release is now dependent upon creating a release. Which is again done by the release notes generator on the main branch

### Jira ticket
None, but forgot to update the version [here](https://github.com/repowerednl/daphne/actions/runs/15729894379/job/44328439760) and thought; a well. A 15min fix with testing

## Checks
- [x] I have tested this 

