### PR TITLE
minimal change for canonical image

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Set docker image tag for '${{ inputs.dockerfile_name }}'
         id: docker-image-tag-env
         env:
-          hub_repo: ${{ inputs.docker_hub_username }}/${{ github.event.repository.name }}
+          hub_repo: docker.io/${{ inputs.docker_hub_username }}/${{ github.event.repository.name }}
         run: |
           DOCKERFILE=${{ inputs.dockerfile_name }}
           DOCKERFILE_NAME=$(echo $DOCKERFILE | sed 's/Dockerfile./-/;s/Dockerfile//')


### PR DESCRIPTION
## Version bump 
#patch

## Summary
Minimal implementation to add the missing 'docker.io/' part for the image canonicalisation

### Questions
Q: do we want to separate the 'latest' image on a different output variable (e.g. image_tag ; image_tag_latest)?

Q: when researching about this the idea of using a digest instead of tags has popped up several times. Do we want to use digests instead of tags for the platform?

### Jira ticket
[IN-283]



[IN-283]: https://repowerednl.atlassian.net/browse/IN-283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ