### PR TITLE
Change token name to actual goal + docs

### DIFF
--- a/.github/workflows/yarn-check-lint-prettier-test-publish.yml
+++ b/.github/workflows/yarn-check-lint-prettier-test-publish.yml
@@ -25,7 +25,9 @@ on:
         description: Whenever the app (i.e. package.json) is not in the root; the location can be specified here
         default: .
     secrets:
-      npm_auth_token:
+      # The token that is used to pull repowerednl packages from GitHub.
+      # Note: The repository needs to be added to the allowed list within the package!
+      packages_auth_token:
         required: true
 
 jobs:
@@ -33,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CI: true
-      NPM_AUTH_TOKEN: ${{ secrets.npm_auth_token }}
+      PACKAGES_AUTH_TOKEN: ${{ secrets.packages_auth_token }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/workflow-templates/vue-test-lint-quality-coverage.yml
+++ b/workflow-templates/vue-test-lint-quality-coverage.yml
@@ -13,6 +13,7 @@ jobs:
   yarn-check-lint-prettier-test-publish:
     permissions:
       contents: write
+      packages: read
     uses: repowerednl/.github/.github/workflows/yarn-check-lint-prettier-test-publish.yml@main
     with:
       should_publish: false # Replace with ${{ endsWith( GITHUB.REF, 'main') }} to enable publishing


### PR DESCRIPTION
## Version bump 
#patch: 
- Change token name to encapsulate the correct goal which is being able to pull our own packages (UICL)
- Update permissions in template to read the packages
