### PR TITLE
Add uv version bumper and fix docs deploy

### DIFF
--- a/.github/workflows/bump-uv-pyproject-toml.yml
+++ b/.github/workflows/bump-uv-pyproject-toml.yml
@@ -38,7 +38,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.ref_name }}
+          ref: ${{ github.ref }}
+          fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Install uv

--- a/.github/workflows/bump-uv-pyproject-toml.yml
+++ b/.github/workflows/bump-uv-pyproject-toml.yml
@@ -63,4 +63,4 @@ jobs:
       - name: Push changes
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: git push origin HEAD
+        run: git push origin HEAD:${GITHUB_REF_NAME}

--- a/.github/workflows/bump-uv-pyproject-toml.yml
+++ b/.github/workflows/bump-uv-pyproject-toml.yml
@@ -17,6 +17,10 @@ on:
     secrets:
       private-key:
         required: true
+      private_pypi_user:
+        required: true
+      private_pypi_password:
+        required: true
 
 jobs:
   update-pyproject-toml:
@@ -42,9 +46,11 @@ jobs:
 
       - name: Bump pyproject.toml version to ${{ inputs.tag }}
         run: |
+          export UV_INDEX_REPOWERED_USERNAME=${{ secrets.private_pypi_user }}
+          export UV_INDEX_REPOWERED_PASSWORD=${{ secrets.private_pypi_password }}
           VERSION="${{ inputs.tag }}"
           VERSION="${VERSION#v}"  # Remove leading 'v' if present
-          uv project version ${{ inputs.tag }}
+          uv version ${{ inputs.tag }}
           git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
           git config user.email "${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
           git add pyproject.toml || true

--- a/.github/workflows/bump-uv-pyproject-toml.yml
+++ b/.github/workflows/bump-uv-pyproject-toml.yml
@@ -35,10 +35,11 @@ jobs:
           app-id: ${{ inputs.app-id }}
           private-key: ${{ secrets.private-key }}
 
-      - name: Checkout repository
+      - name: Checkout (PR-aware)
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
@@ -63,4 +64,4 @@ jobs:
       - name: Push changes
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: git push origin HEAD:${GITHUB_REF_NAME}
+        run: git push origin HEAD

--- a/.github/workflows/bump-uv-pyproject-toml.yml
+++ b/.github/workflows/bump-uv-pyproject-toml.yml
@@ -37,6 +37,9 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref_name }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/bump-uv-pyproject-toml.yml
+++ b/.github/workflows/bump-uv-pyproject-toml.yml
@@ -1,0 +1,56 @@
+name: Update pyproject.toml with a given tag
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+        description: "The Semantic Versioning GitHub tag used for version control"
+      # Optional
+      uv_version:
+        required: true
+        type: string
+      app-id:
+        required: true
+        type: string
+    secrets:
+      private-key:
+        required: true
+
+jobs:
+  update-pyproject-toml:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ inputs.app-id }}
+          private-key: ${{ secrets.private-key }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ inputs.uv_version }}
+          enable-cache: true
+
+      - name: Bump pyproject.toml version to ${{ inputs.tag }}
+        run: |
+          VERSION="${{ inputs.tag }}"
+          VERSION="${VERSION#v}"  # Remove leading 'v' if present
+          uv project version ${{ inputs.tag }}
+          git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
+          git config user.email "${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+          git add pyproject.toml || true
+          git commit -m "Automated version bump to $VERSION [skip ci]" || echo "No changes to commit"
+
+      - name: Push changes
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: git push origin HEAD

--- a/.github/workflows/deploy-uv-sphinx-documentation.yml
+++ b/.github/workflows/deploy-uv-sphinx-documentation.yml
@@ -49,7 +49,7 @@ jobs:
           fetch-depth: 0
 
       - name: UV and Python Setup
-        uses: repowerednl/.github/composite-actions/python-uv-cache@add-bumper-fix-making-docs
+        uses: repowerednl/.github/composite-actions/python-uv-cache@main
         with:
           uv_version: ${{ inputs.uv_version }}
           private_pypi_user: ${{ secrets.private_pypi_user }}

--- a/.github/workflows/deploy-uv-sphinx-documentation.yml
+++ b/.github/workflows/deploy-uv-sphinx-documentation.yml
@@ -41,8 +41,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
+      - name: Checkout (PR-aware)
         uses: actions/checkout@v5
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          fetch-depth: 0
 
       - name: UV and Python Setup
         uses: repowerednl/.github/composite-actions/python-uv-cache@add-bumper-fix-making-docs

--- a/.github/workflows/deploy-uv-sphinx-documentation.yml
+++ b/.github/workflows/deploy-uv-sphinx-documentation.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: UV and Python Setup
-        uses: repowerednl/.github/composite-actions/python-uv-cache@add-bumper-fix-making-doc
+        uses: repowerednl/.github/composite-actions/python-uv-cache@add-bumper-fix-making-docs
         with:
           uv_version: ${{ inputs.uv_version }}
           private_pypi_user: ${{ secrets.private_pypi_user }}

--- a/.github/workflows/deploy-uv-sphinx-documentation.yml
+++ b/.github/workflows/deploy-uv-sphinx-documentation.yml
@@ -55,6 +55,7 @@ jobs:
 
       - name: Build documentation
         run: |
+          cd docs
           uv run make html
 
       - name: Deploy documentation

--- a/.github/workflows/deploy-uv-sphinx-documentation.yml
+++ b/.github/workflows/deploy-uv-sphinx-documentation.yml
@@ -6,10 +6,6 @@ on:
       uv_version:
         type: string
         required: true
-
-      tag:
-        type: string
-        required: true
       docs_target:
         description: "The directory where the package's documentation will be deployed (e.g. /home/repowered/docs/<package name>/)"
         type: string
@@ -28,11 +24,9 @@ on:
       docs_source:
         type: string
         default: docs/_build/html
-
       extra_uv_sync_parameters:
         type: string
         default: "--all-extras --group docs"
-
 
     secrets:
       private_pypi_user:
@@ -50,9 +44,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-
       - name: UV and Python Setup
-        uses: repowerednl/.github/composite-actions/python-uv-cache@change-docs-workflow
+        uses: repowerednl/.github/composite-actions/python-uv-cache@add-bumper-fix-making-doc
         with:
           uv_version: ${{ inputs.uv_version }}
           private_pypi_user: ${{ secrets.private_pypi_user }}
@@ -60,14 +53,9 @@ jobs:
           enable_cache: true
           extra_uv_sync_parameters: ${{ inputs.extra_uv_sync_parameters }}
 
-      - name: Install dependencies
-        run: |
-          uv sync ${{ inputs.extra_uv_sync_parameters }}
-
       - name: Build documentation
         run: |
-          uv version ${{ inputs.tag }}
-          uv run --no-sync ${{ inputs.extra_uv_sync_parameters }} make html
+          uv run make html
 
       - name: Deploy documentation
         uses: appleboy/scp-action@v1

--- a/.github/workflows/python-uv-test-coverage-simple.yml
+++ b/.github/workflows/python-uv-test-coverage-simple.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: UV and Python Setup
-        uses: repowerednl/.github/composite-actions/python-uv-cache@change-docs-workflow
+        uses: repowerednl/.github/composite-actions/python-uv-cache@main
         with:
           uv_version: ${{ inputs.uv_version }}
           working_directory: ${{ inputs.working_directory }}

--- a/composite-actions/python-uv-cache/action.yml
+++ b/composite-actions/python-uv-cache/action.yml
@@ -29,11 +29,13 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version-file: "pyproject.toml"
+
     - name: Install uv
       uses: astral-sh/setup-uv@v6
       with:
         version: ${{ inputs.uv_version }}
         enable-cache: ${{ inputs.enable_cache }}
+
     - name: Install the project
       working-directory: ${{ inputs.working_directory }}
       shell: bash

--- a/workflow-templates/test-sphinx-release-pypi.yml
+++ b/workflow-templates/test-sphinx-release-pypi.yml
@@ -65,7 +65,7 @@ jobs:
       tag: ${{ needs.tag.outputs.tag }}
 
   deploy-sphinx-documentation:
-    needs: [create-release]
+    needs: create-release
     # Make sure that the uv/poetry versions are aligned with the selected workflow
     uses: repowerednl/.github/.github/workflows/deploy-uv-sphinx-documentation.yml@main
     # uses: repowerednl/.github/.github/workflows/deploy-sphinx-documentation.yml@main

--- a/workflow-templates/test-sphinx-release-pypi.yml
+++ b/workflow-templates/test-sphinx-release-pypi.yml
@@ -49,7 +49,7 @@ jobs:
     permissions:
       contents: write
     needs: tag
-    uses: repowerednl/.github/workflows/bump-uv-pyproject-toml@add-bumper-fix-making-docs
+    uses: repowerednl/.github/workflows/bump-uv-pyproject-toml@main
     with:
       uv_version: "0.9.4"
       tag: ${{ needs.tag.outputs.tag }}
@@ -67,7 +67,7 @@ jobs:
       tag: ${{ needs.tag.outputs.tag }}
 
   deploy-sphinx-documentation:
-    needs: create-release
+    needs: [create-release, bump-version]
     # Make sure that the uv/poetry versions are aligned with the selected workflow
     uses: repowerednl/.github/.github/workflows/deploy-uv-sphinx-documentation.yml@main
     # uses: repowerednl/.github/.github/workflows/deploy-sphinx-documentation.yml@main

--- a/workflow-templates/test-sphinx-release-pypi.yml
+++ b/workflow-templates/test-sphinx-release-pypi.yml
@@ -49,7 +49,7 @@ jobs:
     permissions:
       contents: write
     needs: tag
-    uses: repowerednl/.github/workflows/bump-uv-pyproject-toml@add-bumper-fix-making-doc
+    uses: repowerednl/.github/workflows/bump-uv-pyproject-toml@add-bumper-fix-making-docs
     with:
       uv_version: "0.9.4"
       tag: ${{ needs.tag.outputs.tag }}

--- a/workflow-templates/test-sphinx-release-pypi.yml
+++ b/workflow-templates/test-sphinx-release-pypi.yml
@@ -56,6 +56,8 @@ jobs:
       app-id: ${{ vars.APP_ID }}
     secrets:
       private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      private_pypi_user: ${{ secrets.PRIVATE_PYPI_USER }}
+      private_pypi_password: ${{ secrets.PRIVATE_PYPI_PASSWORD }}
 
   # This job will only run if ran from the main branch
   create-release:

--- a/workflow-templates/test-sphinx-release-pypi.yml
+++ b/workflow-templates/test-sphinx-release-pypi.yml
@@ -44,6 +44,19 @@ jobs:
       contents: write
     uses: repowerednl/.github/.github/workflows/generate-github-tag.yml@main
 
+  # Only available for uv packages; delete this job otherwise
+  bump-version:
+    permissions:
+      contents: write
+    needs: tag
+    uses: repowerednl/.github/workflows/bump-uv-pyproject-toml@add-bumper-fix-making-doc
+    with:
+      uv_version: "0.9.4"
+      tag: ${{ needs.tag.outputs.tag }}
+      app-id: ${{ vars.APP_ID }}
+    secrets:
+      private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
   # This job will only run if ran from the main branch
   create-release:
     needs: tag
@@ -52,12 +65,11 @@ jobs:
       tag: ${{ needs.tag.outputs.tag }}
 
   deploy-sphinx-documentation:
-    needs: [create-release, tag]
+    needs: [create-release]
     # Make sure that the uv/poetry versions are aligned with the selected workflow
     uses: repowerednl/.github/.github/workflows/deploy-uv-sphinx-documentation.yml@main
     # uses: repowerednl/.github/.github/workflows/deploy-sphinx-documentation.yml@main
     with:
-      tag: ${{ needs.tag.outputs.tag }}
       # python_version: "3.11.2"
       # poetry_version: "1.8.4"
       uv_version: "0.9.4"


### PR DESCRIPTION
## Version bump 
#minor: add version bumpers and use that (+minor other things) to fix docs deployment


Successful run: https://github.com/repowerednl/refeature/actions/runs/19463149482
With versioned docs (I added refeature to the index as well): https://docs.repowered.nl/refeature/


Note: base branch is Alfred's docs-fix branch. Change base to main to take effect immediately
