### PR TITLE
Fetch SHA from PR event in case of 'labeled' workflow trigger

### DIFF
--- a/.github/workflows/generate-github-tag.yml
+++ b/.github/workflows/generate-github-tag.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: '0'
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha }}
 
       - name: Set prerelease flag
         id: set-prerelease-flag


### PR DESCRIPTION
## Version bump 
#patch

## Summary
When triggering a QA deploy through the 'deploy' label, the checkout fails because `github.event.workflow_run` is empty. In that case a fall back to `github.event.pull_request` for fetching the SHA should work.

### Working example
TBD