### PR TITLE
use --take-ownership instead of --force-conflicts

### DIFF
--- a/.github/workflows/deploy-helm-kubernetes.yml
+++ b/.github/workflows/deploy-helm-kubernetes.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Save DigitalOcean kubeconfig with short-lived credentials
         env:
-          expiry-seconds: ${{ vars.KUBE_CRED_EXPIRY_SECOND || 300 }}
+          expiry-seconds: ${{ vars.KUBE_CRED_EXPIRY_SECOND || 900 }}
         run: doctl kubernetes cluster kubeconfig save --expiry-seconds ${{ env.expiry-seconds }} ${{ vars.CLUSTER_NAME }}
 
       - name: Install Helm

--- a/.github/workflows/deploy-helm-kubernetes.yml
+++ b/.github/workflows/deploy-helm-kubernetes.yml
@@ -93,7 +93,7 @@ jobs:
             helm upgrade $DEPLOYMENT_NAME oci://ghcr.io/repowerednl/helm-charts/deployment \
               --namespace $NAMESPACE --reuse-values --set image=$VERSIONED_TAG \
               --version $CONFIGURED_HELM_VERSION \
-              --server-side --force-conflicts --rollback-on-failure --cleanup-on-fail --timeout 10m
+              --take-ownership --rollback-on-failure --cleanup-on-fail --timeout 10m
           else
             # Set the namespace creation flag if it's an initial deployment
             if [[ "$CURRENT_HELM_VERSION" = "null" ]]; then
@@ -109,7 +109,7 @@ jobs:
             helm upgrade --install $DEPLOYMENT_NAME oci://ghcr.io/repowerednl/helm-charts/deployment \
               --version $CONFIGURED_HELM_VERSION --namespace $NAMESPACE $CREATE_NAMESPACE_COMMAND \
               --values ${{ steps.set-values.outputs.VALUES_FILEPATH }} --set image=$VERSIONED_TAG \
-              --server-side --force-conflicts --rollback-on-failure --cleanup-on-fail --timeout 10m
+              --take-ownership --rollback-on-failure --cleanup-on-fail --timeout 10m
           fi
 
       - name: Helm deployment status as summary


### PR DESCRIPTION
## Version bump 
#patch

## Summary
Use --take-ownership only and change kube token expiry time to 15 mins 

- Helm is the single source of truth for everything, including replicas
- kubectl scale works temporarily but gets reverted on next deploy
- previous KUBE_CRED_EXPIRY_SECOND defaults to 5 mins, increased to 15 as deployment sometimes takes longer
