### PR TITLE
set fail-fast to false

### DIFF
--- a/.github/workflows/deploy-helm-kubernetes.yml
+++ b/.github/workflows/deploy-helm-kubernetes.yml
@@ -30,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     strategy:
+      fail-fast: false
       matrix:
         include: ${{ fromJson(inputs.deployment_name-values_file) }}
     permissions:


### PR DESCRIPTION
## Version bump 
#patch

## Summary
Premature cancelling workflows when one fails breaks helm. 
The cancelled workflows are halfway trough migrating and don't have time to rollback.

Setting fail-false to false will let the workers finish their tasks, so a deployment succeeds or gets rollbacked, no half baked state anymore
