### PR TITLE
Initial helmfile workflow + template + config file

### DIFF
--- a/.github/workflows/deploy-helmfile-kubernetes.yml
+++ b/.github/workflows/deploy-helmfile-kubernetes.yml
@@ -48,13 +48,14 @@ jobs:
 
       - name: Deploy
         uses: helmfile/helmfile-action@v2.4.3
+        env:
+          DOCKER_IMAGE_TAG: ${{ inputs.docker_image_tag }}
         with:
           helmfile-version: ${{ vars.HELMFILE_STABLE_VERSION }}
           helm-plugins: https://github.com/databus23/helm-diff
           helmfile-args: >-
             -f deployment/${{ inputs.environment }}/helmfile.yaml apply
             --concurrency 0
-            --state-values-set dockerImageTag=${{ inputs.docker_image_tag }}
             ${{ inputs.selector != '' && format('--selector {0}', inputs.selector) || '' }}
 
       - name: Deployment status summary

--- a/.github/workflows/deploy-helmfile-kubernetes.yml
+++ b/.github/workflows/deploy-helmfile-kubernetes.yml
@@ -12,14 +12,14 @@ on:
       selector:
         type: string
         required: false
-        description: "Helmfile label selector to target specific releases, e.g. 'name=api'"
+        description: "Release name to target a specific release, e.g. 'api'. Leave empty to deploy all releases."
     secrets:
       digital_ocean_access_token:
         required: true
 
 jobs:
   deploy-helmfile:
-    name: Deploy ${{ inputs.selector || '' }}
+    name: Deploy ${{ inputs.selector || 'all' }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     permissions:
@@ -58,7 +58,7 @@ jobs:
           helmfile-args: >-
             -f deployment/${{ inputs.environment }}/helmfile.yaml.gotmpl apply
             --concurrency 0
-            ${{ inputs.selector != '' && format('--selector {0}', inputs.selector) || '' }}
+            ${{ inputs.selector != '' && format('--selector name={0}', inputs.selector) || '' }}
 
       - name: Deployment status summary
         if: success()
@@ -69,7 +69,7 @@ jobs:
           echo "<details><summary>Release status</summary>" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          helmfile -f deployment/${{ inputs.environment }}/helmfile.yaml.gotmpl ${{ inputs.selector != '' && format('--selector {0}', inputs.selector) || '' }} status >> $GITHUB_STEP_SUMMARY 2>&1 || true
+          helmfile -f deployment/${{ inputs.environment }}/helmfile.yaml.gotmpl ${{ inputs.selector != '' && format('--selector name={0}', inputs.selector) || '' }} status >> $GITHUB_STEP_SUMMARY 2>&1 || true
           echo '```' >> $GITHUB_STEP_SUMMARY
           echo "</details>" >> $GITHUB_STEP_SUMMARY
 
@@ -81,7 +81,7 @@ jobs:
           echo "## ❌ Deployment failed" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          HELMFILE_ARGS="-f deployment/${{ inputs.environment }}/helmfile.yaml.gotmpl ${{ inputs.selector != '' && format('--selector {0}', inputs.selector) || '' }}"
+          HELMFILE_ARGS="-f deployment/${{ inputs.environment }}/helmfile.yaml.gotmpl ${{ inputs.selector != '' && format('--selector name={0}', inputs.selector) || '' }}"
 
           # Try rendering templates — catches values errors and helmfile.yaml.gotmpl errors
           TEMPLATE_ERRORS=$(helmfile $HELMFILE_ARGS template 2>&1 >/dev/null | grep 'STDERR' -A 2) || true

--- a/.github/workflows/deploy-helmfile-kubernetes.yml
+++ b/.github/workflows/deploy-helmfile-kubernetes.yml
@@ -57,6 +57,7 @@ jobs:
           DOCKER_IMAGE_TAG: ${{ inputs.docker_image_tag }}
           ENVIRONMENT: ${{ inputs.environment }}
           RELEASE_PREFIX: ${{ inputs.release_prefix }}
+          SELECTOR: ${{ inputs.selector }}
         with:
           helmfile-version: ${{ vars.HELMFILE_STABLE_VERSION }}
           helm-version: ${{ vars.HELM_STABLE_VERSION }}
@@ -64,7 +65,7 @@ jobs:
           helmfile-args: >-
             -f deployment/helmfile.yaml.gotmpl apply
             --concurrency 0
-            --selector name=${{ inputs.selector }}
+            --selector name=${{ env.SELECTOR }}
 
       - name: Deployment status summary
         if: success()

--- a/.github/workflows/deploy-helmfile-kubernetes.yml
+++ b/.github/workflows/deploy-helmfile-kubernetes.yml
@@ -13,6 +13,11 @@ on:
         type: string
         required: true
         description: "Release name to deploy, e.g. 'api'. Must match a release name in helmfile.yaml.gotmpl."
+      release_prefix:
+        type: string
+        required: false
+        default: ''
+        description: "Optional prefix prepended to release names in helmfile (e.g. 'test-' for canary deploys)."
     secrets:
       digital_ocean_access_token:
         required: true
@@ -51,6 +56,7 @@ jobs:
         env:
           DOCKER_IMAGE_TAG: ${{ inputs.docker_image_tag }}
           ENVIRONMENT: ${{ inputs.environment }}
+          RELEASE_PREFIX: ${{ inputs.release_prefix }}
         with:
           helmfile-version: ${{ vars.HELMFILE_STABLE_VERSION }}
           helm-version: ${{ vars.HELM_STABLE_VERSION }}
@@ -65,6 +71,7 @@ jobs:
         env:
           DOCKER_IMAGE_TAG: ${{ inputs.docker_image_tag }}
           ENVIRONMENT: ${{ inputs.environment }}
+          RELEASE_PREFIX: ${{ inputs.release_prefix }}
         run: |
           echo "## ✅ Deployment succeeded" >> $GITHUB_STEP_SUMMARY
           echo "<details><summary>Release status</summary>" >> $GITHUB_STEP_SUMMARY
@@ -80,6 +87,7 @@ jobs:
         env:
           DOCKER_IMAGE_TAG: ${{ inputs.docker_image_tag }}
           ENVIRONMENT: ${{ inputs.environment }}
+          RELEASE_PREFIX: ${{ inputs.release_prefix }}
           SELECTOR: ${{ inputs.selector }}
         with:
           script: |

--- a/.github/workflows/deploy-helmfile-kubernetes.yml
+++ b/.github/workflows/deploy-helmfile-kubernetes.yml
@@ -56,7 +56,7 @@ jobs:
           helm-version: ${{ vars.HELM_STABLE_VERSION }}
           helm-plugins: https://github.com/databus23/helm-diff
           helmfile-args: >-
-            -f deployment/${{ inputs.environment }}/helmfile.yaml.gotmpl apply
+            -f deployment/helmfile.yaml.gotmpl apply
             --concurrency 0
             ${{ inputs.selector != '' && format('--selector name={0}', inputs.selector) || '' }}
 
@@ -69,7 +69,7 @@ jobs:
           echo "<details><summary>Release status</summary>" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          helmfile -f deployment/${{ inputs.environment }}/helmfile.yaml.gotmpl ${{ inputs.selector != '' && format('--selector name={0}', inputs.selector) || '' }} status >> $GITHUB_STEP_SUMMARY 2>&1 || true
+          helmfile -f deployment/helmfile.yaml.gotmpl ${{ inputs.selector != '' && format('--selector name={0}', inputs.selector) || '' }} status >> $GITHUB_STEP_SUMMARY 2>&1 || true
           echo '```' >> $GITHUB_STEP_SUMMARY
           echo "</details>" >> $GITHUB_STEP_SUMMARY
 
@@ -98,7 +98,7 @@ jobs:
             if (tmpl.exitCode !== 0) {
               await core.summary
                 .addHeading('Configuration error', 3)
-                .addRaw('_The chart could not be rendered or processed. Check your `helmfile.yaml.gotmpl` or helm `values.yaml` file(s)._\n\n')
+                .addQuote('The chart could not be rendered or processed. Check your helmfile.yaml.gotmpl or helm values.yaml file(s).')
                 .addCodeBlock((tmpl.stderr || tmpl.stdout).trim())
                 .write();
               return;
@@ -124,7 +124,7 @@ jobs:
 
             core.summary
               .addHeading('Cluster installation error', 3)
-              .addRaw('_Templates rendered successfully — the error occurred during installation on the cluster._\n\n')
+              .addQuote('Templates rendered successfully — the error occurred during installation on the cluster.')
               .addTable([
                 [{data: 'Release', header: true}, {data: 'Namespace', header: true}, {data: 'Status', header: true}],
                 ...statuses.map(({ name, ns, status }) => [name, ns, `${statusIcon(status)} ${status}`])

--- a/.github/workflows/deploy-helmfile-kubernetes.yml
+++ b/.github/workflows/deploy-helmfile-kubernetes.yml
@@ -18,8 +18,7 @@ on:
         required: true
 
 jobs:
-  deploy-helmfile:
-    name: Deploy ${{ inputs.selector || 'all' }}
+  deploy:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     permissions:

--- a/.github/workflows/deploy-helmfile-kubernetes.yml
+++ b/.github/workflows/deploy-helmfile-kubernetes.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@v2.5.1
         with:
           token: ${{ secrets.digital_ocean_access_token }}
 
@@ -58,10 +58,32 @@ jobs:
             ${{ inputs.selector != '' && format('--selector {0}', inputs.selector) || '' }}
 
       - name: Deployment status summary
-        if: always()
+        if: success()
         run: |
-          echo "## Helmfile Status" >> $GITHUB_STEP_SUMMARY
+          echo "## Deployment succeeded" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
           helmfile -f deployment/${{ inputs.environment }}/helmfile.yaml status >> $GITHUB_STEP_SUMMARY 2>&1 || true
-          echo "Image tag: ${{ inputs.docker_image_tag }}" >> $GITHUB_STEP_SUMMARY
-        env:
-          ENVIRONMENT: ${{ inputs.environment }}
+
+      - name: Deployment failure summary
+        if: failure()
+        run: |
+          echo "## ❌ Deployment failed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          HELMFILE_ARGS="-f deployment/${{ inputs.environment }}/helmfile.yaml"
+
+          # Try rendering templates — catches values errors and helmfile.yaml errors
+          TEMPLATE_ERRORS=$(helmfile $HELMFILE_ARGS template 2>&1 >/dev/null | grep 'STDERR' -A 2) || true
+          if [ -n "$TEMPLATE_ERRORS" ]; then
+            echo "### Configuration error" >> $GITHUB_STEP_SUMMARY
+            echo "_The chart could not be rendered. Check your \`helmfile.yaml\` or helm \`values.yaml\` file(s)._" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "$TEMPLATE_ERRORS" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          else
+            echo "### Cluster installation error" >> $GITHUB_STEP_SUMMARY
+            echo "_The error occurred during installation on the cluster._" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            helmfile $HELMFILE_ARGS status 2>&1 >> $GITHUB_STEP_SUMMARY || true
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/deploy-helmfile-kubernetes.yml
+++ b/.github/workflows/deploy-helmfile-kubernetes.yml
@@ -89,6 +89,11 @@ jobs:
               return (match?.[1] ?? raw).trim();
             };
 
+            const parseReleases = stdout => stdout.split('\n').slice(1).filter(Boolean).map(line => {
+              const [name, ns] = line.trim().split(/\s+/);
+              return { name, ns };
+            }).filter(r => r.name && r.ns);
+
             const baseArgs = ['-f', 'deployment/helmfile.yaml.gotmpl'];
             const selectorArgs = process.env.SELECTOR ? ['--selector', `name=${process.env.SELECTOR}`] : [];
             const helmfileArgs = cmd => [...baseArgs, cmd, ...selectorArgs];
@@ -98,28 +103,47 @@ jobs:
 
             await core.summary.addHeading('❌ Deployment failed', 2);
 
-            // Case 1 & 2: detect config/template errors
+            // Get release list — works even when templates/values fail
+            const list = await exec.getExecOutput('helmfile', helmfileArgs('list'), {
+              ignoreReturnCode: true, silent: true
+            });
+            const releases = parseReleases(list.stdout);
+
+            // Detect config/template errors
             const tmpl = await exec.getExecOutput('helmfile', helmfileArgs('template'), {
               ignoreReturnCode: true, silent: true
             });
             if (tmpl.exitCode !== 0) {
-              await core.summary
+              core.summary
                 .addHeading('Configuration error', 3)
-                .addQuote('The chart could not be rendered or processed. Check your helmfile.yaml.gotmpl or helm values.yaml file(s).')
-                .addCodeBlock(extractError(tmpl.stderr || tmpl.stdout))
-                .write();
+                .addQuote('The chart could not be rendered or processed. Check your helmfile.yaml.gotmpl or helm values.yaml file(s).');
+
+              if (releases.length > 1) {
+                // Check each release individually to show which ones fail
+                const perRelease = await Promise.all(releases.map(async ({ name, ns }) => {
+                  const r = await exec.getExecOutput('helmfile', [
+                    ...baseArgs, 'template', '--selector', `name=${name}`
+                  ], { ignoreReturnCode: true, silent: true });
+                  return { name, ns, ok: r.exitCode === 0, error: extractError(r.stderr || r.stdout) };
+                }));
+
+                core.summary.addTable([
+                  [{data: 'Release', header: true}, {data: 'Namespace', header: true}, {data: 'Status', header: true}],
+                  ...perRelease.map(({ name, ns, ok }) => [name, ns, ok ? '✅ ok' : '❌ error'])
+                ]);
+
+                for (const { name, error } of perRelease.filter(r => !r.ok)) {
+                  core.summary.addDetails(name, `\n\n\`\`\`\n${error}\n\`\`\`\n`);
+                }
+              } else {
+                core.summary.addCodeBlock(extractError(tmpl.stderr || tmpl.stdout));
+              }
+
+              await core.summary.write();
               return;
             }
 
-            // Case 3: cluster installation error — get releases then fetch statuses in parallel
-            const list = await exec.getExecOutput('helmfile', helmfileArgs('list'), {
-              ignoreReturnCode: true, silent: true
-            });
-            const releases = list.stdout.split('\n').slice(1).filter(Boolean).map(line => {
-              const [name, ns] = line.trim().split(/\s+/);
-              return { name, ns };
-            }).filter(r => r.name && r.ns);
-
+            // Cluster installation error — fetch helm status per release in parallel
             const statuses = await Promise.all(releases.map(async ({ name, ns }) => {
               const result = await exec.getExecOutput('helm', ['status', name, '-n', ns], {
                 ignoreReturnCode: true, silent: true

--- a/.github/workflows/deploy-helmfile-kubernetes.yml
+++ b/.github/workflows/deploy-helmfile-kubernetes.yml
@@ -24,6 +24,9 @@ jobs:
     permissions:
       packages: read
       contents: read
+    env:
+      GHCR_USERNAME: repowerednl
+      GHCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout ${{ github.repository }}
         uses: actions/checkout@v6
@@ -42,13 +45,12 @@ jobs:
         uses: helmfile/helmfile-action@v2
         with:
           helmfile-version: "v0.171.0"
-          helm-version: "v3.17.3"
+          helm-version: "v3.18.0"
           helm-plugins: https://github.com/databus23/helm-diff
           helmfile-args: >-
             -f deployment/${{ inputs.environment }}/helmfile.yaml apply
             --concurrency 0
             --state-values-set dockerImageTag=${{ inputs.docker_image_tag }}
-            --state-values-set ghcrToken=${{ secrets.GITHUB_TOKEN }}
             ${{ inputs.selector != '' && format('--selector {0}', inputs.selector) || '' }}
 
       - name: Deployment status summary

--- a/.github/workflows/deploy-helmfile-kubernetes.yml
+++ b/.github/workflows/deploy-helmfile-kubernetes.yml
@@ -40,6 +40,8 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@v5
+        with:
+          version: "v3.17.3"
 
       - name: Login to GitHub Container Registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u repowerednl --password-stdin

--- a/.github/workflows/deploy-helmfile-kubernetes.yml
+++ b/.github/workflows/deploy-helmfile-kubernetes.yml
@@ -26,7 +26,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout ${{ github.repository }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install doctl
         uses: digitalocean/action-doctl@v2
@@ -39,7 +39,7 @@ jobs:
         run: doctl kubernetes cluster kubeconfig save --expiry-seconds ${{ env.expiry-seconds }} ${{ vars.CLUSTER_NAME }}
 
       - name: Install Helm
-        uses: azure/setup-helm@v4.3.0
+        uses: azure/setup-helm@v5
 
       - name: Login to GitHub Container Registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u repowerednl --password-stdin
@@ -51,10 +51,9 @@ jobs:
           helm-plugins: https://github.com/databus23/helm-diff
           helmfile-args: >-
             -f deployment/${{ inputs.environment }}/helmfile.yaml apply
+            --concurrency 0
+            --state-values-set dockerImageTag=${{ inputs.docker_image_tag }}
             ${{ inputs.selector != '' && format('--selector {0}', inputs.selector) || '' }}
-        env:
-          DOCKER_IMAGE_TAG: ${{ inputs.docker_image_tag }}
-          ENVIRONMENT: ${{ inputs.environment }}
 
       - name: Deployment status summary
         if: always()

--- a/.github/workflows/deploy-helmfile-kubernetes.yml
+++ b/.github/workflows/deploy-helmfile-kubernetes.yml
@@ -24,9 +24,6 @@ jobs:
     permissions:
       packages: read
       contents: read
-    env:
-      GHCR_USERNAME: repowerednl
-      GHCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout ${{ github.repository }}
         uses: actions/checkout@v6
@@ -41,11 +38,18 @@ jobs:
           expiry-seconds: ${{ vars.KUBE_CRED_EXPIRY_SECOND || 300 }}
         run: doctl kubernetes cluster kubeconfig save --expiry-seconds ${{ env.expiry-seconds }} ${{ vars.CLUSTER_NAME }}
 
-      - name: Deploy
-        uses: helmfile/helmfile-action@v2
+      - name: Install Helm
+        uses: azure/setup-helm@v5
         with:
-          helmfile-version: "v0.171.0"
-          helm-version: "v3.18.0"
+          version: ${{ vars.HELM_STABLE_VERSION }}
+
+      - name: Helm packages login
+        run: helm registry login ghcr.io --username repowerednl --password ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Deploy
+        uses: helmfile/helmfile-action@v2.4.3
+        with:
+          helmfile-version: ${{ vars.HELMFILE_STABLE_VERSION }}
           helm-plugins: https://github.com/databus23/helm-diff
           helmfile-args: >-
             -f deployment/${{ inputs.environment }}/helmfile.yaml apply

--- a/.github/workflows/deploy-helmfile-kubernetes.yml
+++ b/.github/workflows/deploy-helmfile-kubernetes.yml
@@ -72,12 +72,14 @@ jobs:
           DOCKER_IMAGE_TAG: ${{ inputs.docker_image_tag }}
           ENVIRONMENT: ${{ inputs.environment }}
           RELEASE_PREFIX: ${{ inputs.release_prefix }}
+          SELECTOR: ${{ inputs.selector }}
         run: |
           echo "## ✅ Deployment succeeded" >> $GITHUB_STEP_SUMMARY
           echo "<details><summary>Release status</summary>" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          helmfile -f deployment/helmfile.yaml.gotmpl --selector name=${{ inputs.selector }} status >> $GITHUB_STEP_SUMMARY 2>&1 || true
+          # Errors are silently swallowed here — we don't want a status failure to fail the summary step
+          helmfile -f deployment/helmfile.yaml.gotmpl --selector "name=$SELECTOR" status >> $GITHUB_STEP_SUMMARY 2>&1 || true
           echo '```' >> $GITHUB_STEP_SUMMARY
           echo "</details>" >> $GITHUB_STEP_SUMMARY
 
@@ -91,50 +93,68 @@ jobs:
           SELECTOR: ${{ inputs.selector }}
         with:
           script: |
-            const extractError = raw => {
+            // ── Helpers ────────────────────────────────────────────────────────────
+      
+            const baseHelmfileArgs = [
+              '-f', 'deployment/helmfile.yaml.gotmpl',
+              '--selector', `name=${process.env.SELECTOR}`,
+            ];
+      
+            const failedStatuses = ['failed', 'pending-install', 'pending-upgrade', 'pending-rollback'];
+            const statusIcon = s => s === 'deployed' ? '✅' : failedStatuses.includes(s) ? '❌' : '⚠️';
+      
+            const extractStderr = raw => {
               const match = raw.match(/^STDERR:\n([\s\S]+?)(?=\n(?:COMBINED OUTPUT|EXIT STATUS):|$)/m);
               return (match?.[1] ?? raw).trim();
             };
-
-            const helmfileArgs = cmd => [
-              '-f', 'deployment/helmfile.yaml.gotmpl',
-              cmd,
-              '--selector', `name=${process.env.SELECTOR}`
-            ];
-
-            const failedStatuses = ['failed', 'pending-install', 'pending-upgrade', 'pending-rollback'];
-            const statusIcon = s => s === 'deployed' ? '✅' : failedStatuses.includes(s) ? '❌' : '⚠️';
-
+      
+            // ── Step 1: detect config/template errors ──────────────────────────────
+      
             await core.summary.addHeading('❌ Deployment failed', 2);
-
-            // Detect config/template errors
-            const tmpl = await exec.getExecOutput('helmfile', helmfileArgs('template'), {
-              ignoreReturnCode: true, silent: true
+      
+            const tmpl = await exec.getExecOutput('helmfile', [...baseHelmfileArgs, 'template'], {
+              ignoreReturnCode: true,
+              silent: true,
             });
+      
             if (tmpl.exitCode !== 0) {
               await core.summary
                 .addHeading('Configuration error', 3)
                 .addQuote('The chart could not be rendered or processed. Check your helmfile.yaml.gotmpl or helm values.yaml file(s).')
-                .addCodeBlock(extractError(tmpl.stderr || tmpl.stdout))
+                .addCodeBlock(extractStderr(tmpl.stderr || tmpl.stdout))
                 .write();
               return;
             }
-
-            // Cluster installation error — get release namespace then fetch helm status
-            const list = await exec.getExecOutput('helmfile', helmfileArgs('list'), {
-              ignoreReturnCode: true, silent: true
+      
+            // ── Step 2: templates rendered OK — error occurred on the cluster ──────
+      
+            const list = await exec.getExecOutput('helmfile', [...baseHelmfileArgs, 'list'], {
+              ignoreReturnCode: true,
+              silent: true,
             });
-            const [name, ns] = list.stdout.split('\n').slice(1).filter(Boolean)[0]?.trim().split(/\s+/) ?? [];
-
-            const result = await exec.getExecOutput('helm', ['status', name, '-n', ns], {
-              ignoreReturnCode: true, silent: true
+      
+            // Parse the first data row of helmfile list's output (skiping the header); the first row gives the release name and namespace.
+            const release = list.stdout.split('\n').slice(1).find(Boolean)?.trim().split(/\s+/);
+            if (!release) {
+              await core.summary
+                .addHeading('Cluster installation error', 3)
+                .addQuote('Templates rendered successfully, but no release was found. No release matched the selector.')
+                .write();
+              return;
+            }
+            const [name, namespace] = release;
+      
+            const helmStatus = await exec.getExecOutput('helm', ['status', name, '-n', namespace], {
+              ignoreReturnCode: true,
+              silent: true,
             });
-            const output = result.stdout || result.stderr;
-            const status = output.match(/^STATUS:\s+(\S+)/m)?.[1] ?? 'not found';
-
+      
+            const rawOutput = helmStatus.stdout || helmStatus.stderr;
+            const status = rawOutput.match(/^STATUS:\s+(\S+)/m)?.[1] ?? 'not found';
+      
             await core.summary
               .addHeading('Cluster installation error', 3)
               .addQuote('Templates rendered successfully — the error occurred during installation on the cluster.')
               .addRaw(`**${statusIcon(status)} ${name}** — \`${status}\`\n\n`)
-              .addDetails('helm status output', `\n\n\`\`\`\n${output.trim()}\n\`\`\`\n`)
+              .addDetails('helm status output', `\n\n\`\`\`\n${rawOutput.trim()}\n\`\`\`\n`)
               .write();

--- a/.github/workflows/deploy-helmfile-kubernetes.yml
+++ b/.github/workflows/deploy-helmfile-kubernetes.yml
@@ -59,10 +59,9 @@ jobs:
 
       - name: Deployment status summary
         if: always()
-        continue-on-error: true
         run: |
           echo "## Helmfile Status" >> $GITHUB_STEP_SUMMARY
-          helmfile -f deployment/${{ inputs.environment }}/helmfile.yaml status >> $GITHUB_STEP_SUMMARY
+          helmfile -f deployment/${{ inputs.environment }}/helmfile.yaml status >> $GITHUB_STEP_SUMMARY 2>&1 || true
           echo "Image tag: ${{ inputs.docker_image_tag }}" >> $GITHUB_STEP_SUMMARY
         env:
           ENVIRONMENT: ${{ inputs.environment }}

--- a/.github/workflows/deploy-helmfile-kubernetes.yml
+++ b/.github/workflows/deploy-helmfile-kubernetes.yml
@@ -55,7 +55,7 @@ jobs:
           helm-version: ${{ vars.HELM_STABLE_VERSION }}
           helm-plugins: https://github.com/databus23/helm-diff
           helmfile-args: >-
-            -f deployment/${{ inputs.environment }}/helmfile.yaml apply
+            -f deployment/${{ inputs.environment }}/helmfile.yaml.gotmpl apply
             --concurrency 0
             ${{ inputs.selector != '' && format('--selector {0}', inputs.selector) || '' }}
 
@@ -64,7 +64,7 @@ jobs:
         run: |
           echo "## Deployment succeeded" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          helmfile -f deployment/${{ inputs.environment }}/helmfile.yaml status >> $GITHUB_STEP_SUMMARY 2>&1 || true
+          helmfile -f deployment/${{ inputs.environment }}/helmfile.yaml.gotmpl status >> $GITHUB_STEP_SUMMARY 2>&1 || true
 
       - name: Deployment failure summary
         if: failure()
@@ -72,13 +72,13 @@ jobs:
           echo "## ❌ Deployment failed" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          HELMFILE_ARGS="-f deployment/${{ inputs.environment }}/helmfile.yaml"
+          HELMFILE_ARGS="-f deployment/${{ inputs.environment }}/helmfile.yaml.gotmpl"
 
-          # Try rendering templates — catches values errors and helmfile.yaml errors
+          # Try rendering templates — catches values errors and helmfile.yaml.gotmpl errors
           TEMPLATE_ERRORS=$(helmfile $HELMFILE_ARGS template 2>&1 >/dev/null | grep 'STDERR' -A 2) || true
           if [ -n "$TEMPLATE_ERRORS" ]; then
             echo "### Configuration error" >> $GITHUB_STEP_SUMMARY
-            echo "_The chart could not be rendered. Check your \`helmfile.yaml\` or helm \`values.yaml\` file(s)._" >> $GITHUB_STEP_SUMMARY
+            echo "_The chart could not be rendered. Check your \`helmfile.yaml.gotmpl\` or helm \`values.yaml\` file(s)._" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
             echo "$TEMPLATE_ERRORS" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-helmfile-kubernetes.yml
+++ b/.github/workflows/deploy-helmfile-kubernetes.yml
@@ -52,6 +52,7 @@ jobs:
           DOCKER_IMAGE_TAG: ${{ inputs.docker_image_tag }}
         with:
           helmfile-version: ${{ vars.HELMFILE_STABLE_VERSION }}
+          helm-version: ${{ vars.HELM_STABLE_VERSION }}
           helm-plugins: https://github.com/databus23/helm-diff
           helmfile-args: >-
             -f deployment/${{ inputs.environment }}/helmfile.yaml apply

--- a/.github/workflows/deploy-helmfile-kubernetes.yml
+++ b/.github/workflows/deploy-helmfile-kubernetes.yml
@@ -19,6 +19,7 @@ on:
 
 jobs:
   deploy-helmfile:
+    name: Deploy ${{ inputs.selector || '' }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     permissions:
@@ -61,18 +62,26 @@ jobs:
 
       - name: Deployment status summary
         if: success()
+        env:
+          DOCKER_IMAGE_TAG: ${{ inputs.docker_image_tag }}
         run: |
-          echo "## Deployment succeeded" >> $GITHUB_STEP_SUMMARY
+          echo "## ✅ Deployment succeeded" >> $GITHUB_STEP_SUMMARY
+          echo "<details><summary>Release status</summary>" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          helmfile -f deployment/${{ inputs.environment }}/helmfile.yaml.gotmpl status >> $GITHUB_STEP_SUMMARY 2>&1 || true
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          helmfile -f deployment/${{ inputs.environment }}/helmfile.yaml.gotmpl ${{ inputs.selector != '' && format('--selector {0}', inputs.selector) || '' }} status >> $GITHUB_STEP_SUMMARY 2>&1 || true
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "</details>" >> $GITHUB_STEP_SUMMARY
 
       - name: Deployment failure summary
         if: failure()
+        env:
+          DOCKER_IMAGE_TAG: ${{ inputs.docker_image_tag }}
         run: |
           echo "## ❌ Deployment failed" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          HELMFILE_ARGS="-f deployment/${{ inputs.environment }}/helmfile.yaml.gotmpl"
+          HELMFILE_ARGS="-f deployment/${{ inputs.environment }}/helmfile.yaml.gotmpl ${{ inputs.selector != '' && format('--selector {0}', inputs.selector) || '' }}"
 
           # Try rendering templates — catches values errors and helmfile.yaml.gotmpl errors
           TEMPLATE_ERRORS=$(helmfile $HELMFILE_ARGS template 2>&1 >/dev/null | grep 'STDERR' -A 2) || true
@@ -86,6 +95,6 @@ jobs:
             echo "### Cluster installation error" >> $GITHUB_STEP_SUMMARY
             echo "_The error occurred during installation on the cluster._" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
-            helmfile $HELMFILE_ARGS status 2>&1 >> $GITHUB_STEP_SUMMARY || true
+            helmfile $HELMFILE_ARGS status >> $GITHUB_STEP_SUMMARY 2>&1 || true
             echo '```' >> $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/deploy-helmfile-kubernetes.yml
+++ b/.github/workflows/deploy-helmfile-kubernetes.yml
@@ -51,6 +51,7 @@ jobs:
         uses: helmfile/helmfile-action@v2.4.3
         env:
           DOCKER_IMAGE_TAG: ${{ inputs.docker_image_tag }}
+          ENVIRONMENT: ${{ inputs.environment }}
         with:
           helmfile-version: ${{ vars.HELMFILE_STABLE_VERSION }}
           helm-version: ${{ vars.HELM_STABLE_VERSION }}
@@ -64,6 +65,7 @@ jobs:
         if: success()
         env:
           DOCKER_IMAGE_TAG: ${{ inputs.docker_image_tag }}
+          ENVIRONMENT: ${{ inputs.environment }}
         run: |
           echo "## ✅ Deployment succeeded" >> $GITHUB_STEP_SUMMARY
           echo "<details><summary>Release status</summary>" >> $GITHUB_STEP_SUMMARY
@@ -82,7 +84,12 @@ jobs:
           SELECTOR: ${{ inputs.selector }}
         with:
           script: |
-            const baseArgs = ['-f', `deployment/${process.env.ENVIRONMENT}/helmfile.yaml.gotmpl`];
+            const extractError = raw => {
+              const match = raw.match(/^STDERR:\n([\s\S]+?)(?=\n(?:COMBINED OUTPUT|EXIT STATUS):|$)/m);
+              return (match?.[1] ?? raw).trim();
+            };
+
+            const baseArgs = ['-f', 'deployment/helmfile.yaml.gotmpl'];
             const selectorArgs = process.env.SELECTOR ? ['--selector', `name=${process.env.SELECTOR}`] : [];
             const helmfileArgs = cmd => [...baseArgs, cmd, ...selectorArgs];
 
@@ -99,7 +106,7 @@ jobs:
               await core.summary
                 .addHeading('Configuration error', 3)
                 .addQuote('The chart could not be rendered or processed. Check your helmfile.yaml.gotmpl or helm values.yaml file(s).')
-                .addCodeBlock((tmpl.stderr || tmpl.stdout).trim())
+                .addCodeBlock(extractError(tmpl.stderr || tmpl.stdout))
                 .write();
               return;
             }

--- a/.github/workflows/deploy-helmfile-kubernetes.yml
+++ b/.github/workflows/deploy-helmfile-kubernetes.yml
@@ -75,51 +75,63 @@ jobs:
 
       - name: Deployment failure summary
         if: failure()
+        uses: actions/github-script@v7
         env:
           DOCKER_IMAGE_TAG: ${{ inputs.docker_image_tag }}
-        run: |
-          echo "## ❌ Deployment failed" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          ENVIRONMENT: ${{ inputs.environment }}
+          SELECTOR: ${{ inputs.selector }}
+        with:
+          script: |
+            const baseArgs = ['-f', `deployment/${process.env.ENVIRONMENT}/helmfile.yaml.gotmpl`];
+            const selectorArgs = process.env.SELECTOR ? ['--selector', `name=${process.env.SELECTOR}`] : [];
+            const helmfileArgs = cmd => [...baseArgs, cmd, ...selectorArgs];
 
-          HELMFILE_ARGS="-f deployment/${{ inputs.environment }}/helmfile.yaml.gotmpl ${{ inputs.selector != '' && format('--selector name={0}', inputs.selector) || '' }}"
+            const failedStatuses = ['failed', 'pending-install', 'pending-upgrade', 'pending-rollback'];
+            const statusIcon = s => s === 'deployed' ? '✅' : failedStatuses.includes(s) ? '❌' : '⚠️';
 
-          # Try rendering templates — catches values errors and helmfile.yaml.gotmpl errors
-          TEMPLATE_ERRORS=$(helmfile $HELMFILE_ARGS template 2>&1 >/dev/null | grep 'STDERR' -A 2) || true
-          if [ -n "$TEMPLATE_ERRORS" ]; then
-            echo "### Configuration error" >> $GITHUB_STEP_SUMMARY
-            echo "_The chart could not be rendered. Check your \`helmfile.yaml.gotmpl\` or helm \`values.yaml\` file(s)._" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            echo "$TEMPLATE_ERRORS" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-          else
-            echo "### Cluster installation error" >> $GITHUB_STEP_SUMMARY
-            echo "_Templates rendered successfully — the error occurred during installation on the cluster._" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            declare -A helm_output
-            while read -r name ns; do
-              helm_output["$name:$ns"]=$(helm status "$name" -n "$ns" 2>&1) || true
-            done < <(helmfile $HELMFILE_ARGS list 2>/dev/null | awk 'NR>1 {print $1, $2}')
+            await core.summary.addHeading('❌ Deployment failed', 2);
 
-            echo "| Release | Namespace | Status |" >> $GITHUB_STEP_SUMMARY
-            echo "| --- | --- | --- |" >> $GITHUB_STEP_SUMMARY
-            for key in "${!helm_output[@]}"; do
-              name="${key%%:*}"; ns="${key##*:}"
-              status=$(echo "${helm_output[$key]}" | awk '/^STATUS:/{print $2}')
-              case "${status:-not found}" in
-                deployed) icon="✅" ;;
-                failed|pending-install|pending-upgrade|pending-rollback) icon="❌" ;;
-                *) icon="⚠️" ;;
-              esac
-              echo "| $name | $ns | $icon ${status:-not found} |" >> $GITHUB_STEP_SUMMARY
-            done
-            echo "" >> $GITHUB_STEP_SUMMARY
-            for key in "${!helm_output[@]}"; do
-              name="${key%%:*}"
-              echo "<details><summary>$name</summary>" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo '```' >> $GITHUB_STEP_SUMMARY
-              echo "${helm_output[$key]}" >> $GITHUB_STEP_SUMMARY
-              echo '```' >> $GITHUB_STEP_SUMMARY
-              echo "</details>" >> $GITHUB_STEP_SUMMARY
-            done
-          fi
+            // Case 1 & 2: detect config/template errors
+            const tmpl = await exec.getExecOutput('helmfile', helmfileArgs('template'), {
+              ignoreReturnCode: true, silent: true
+            });
+            if (tmpl.exitCode !== 0) {
+              await core.summary
+                .addHeading('Configuration error', 3)
+                .addRaw('_The chart could not be rendered or processed. Check your `helmfile.yaml.gotmpl` or helm `values.yaml` file(s)._\n\n')
+                .addCodeBlock((tmpl.stderr || tmpl.stdout).trim())
+                .write();
+              return;
+            }
+
+            // Case 3: cluster installation error — get releases then fetch statuses in parallel
+            const list = await exec.getExecOutput('helmfile', helmfileArgs('list'), {
+              ignoreReturnCode: true, silent: true
+            });
+            const releases = list.stdout.split('\n').slice(1).filter(Boolean).map(line => {
+              const [name, ns] = line.trim().split(/\s+/);
+              return { name, ns };
+            }).filter(r => r.name && r.ns);
+
+            const statuses = await Promise.all(releases.map(async ({ name, ns }) => {
+              const result = await exec.getExecOutput('helm', ['status', name, '-n', ns], {
+                ignoreReturnCode: true, silent: true
+              });
+              const output = result.stdout || result.stderr;
+              const status = output.match(/^STATUS:\s+(\S+)/m)?.[1] ?? 'not found';
+              return { name, ns, status, output };
+            }));
+
+            core.summary
+              .addHeading('Cluster installation error', 3)
+              .addRaw('_Templates rendered successfully — the error occurred during installation on the cluster._\n\n')
+              .addTable([
+                [{data: 'Release', header: true}, {data: 'Namespace', header: true}, {data: 'Status', header: true}],
+                ...statuses.map(({ name, ns, status }) => [name, ns, `${statusIcon(status)} ${status}`])
+              ]);
+
+            for (const { name, output } of statuses) {
+              core.summary.addDetails(name, `\n\n\`\`\`\n${output.trim()}\n\`\`\`\n`);
+            }
+
+            await core.summary.write();

--- a/.github/workflows/deploy-helmfile-kubernetes.yml
+++ b/.github/workflows/deploy-helmfile-kubernetes.yml
@@ -93,8 +93,33 @@ jobs:
             echo '```' >> $GITHUB_STEP_SUMMARY
           else
             echo "### Cluster installation error" >> $GITHUB_STEP_SUMMARY
-            echo "_The error occurred during installation on the cluster._" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            helmfile $HELMFILE_ARGS status >> $GITHUB_STEP_SUMMARY 2>&1 || true
-            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "_Templates rendered successfully — the error occurred during installation on the cluster._" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            declare -A helm_output
+            while read -r name ns; do
+              helm_output["$name:$ns"]=$(helm status "$name" -n "$ns" 2>&1) || true
+            done < <(helmfile $HELMFILE_ARGS list 2>/dev/null | awk 'NR>1 {print $1, $2}')
+
+            echo "| Release | Namespace | Status |" >> $GITHUB_STEP_SUMMARY
+            echo "| --- | --- | --- |" >> $GITHUB_STEP_SUMMARY
+            for key in "${!helm_output[@]}"; do
+              name="${key%%:*}"; ns="${key##*:}"
+              status=$(echo "${helm_output[$key]}" | awk '/^STATUS:/{print $2}')
+              case "${status:-not found}" in
+                deployed) icon="✅" ;;
+                failed|pending-install|pending-upgrade|pending-rollback) icon="❌" ;;
+                *) icon="⚠️" ;;
+              esac
+              echo "| $name | $ns | $icon ${status:-not found} |" >> $GITHUB_STEP_SUMMARY
+            done
+            echo "" >> $GITHUB_STEP_SUMMARY
+            for key in "${!helm_output[@]}"; do
+              name="${key%%:*}"
+              echo "<details><summary>$name</summary>" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo '```' >> $GITHUB_STEP_SUMMARY
+              echo "${helm_output[$key]}" >> $GITHUB_STEP_SUMMARY
+              echo '```' >> $GITHUB_STEP_SUMMARY
+              echo "</details>" >> $GITHUB_STEP_SUMMARY
+            done
           fi

--- a/.github/workflows/deploy-helmfile-kubernetes.yml
+++ b/.github/workflows/deploy-helmfile-kubernetes.yml
@@ -38,23 +38,17 @@ jobs:
           expiry-seconds: ${{ vars.KUBE_CRED_EXPIRY_SECOND || 300 }}
         run: doctl kubernetes cluster kubeconfig save --expiry-seconds ${{ env.expiry-seconds }} ${{ vars.CLUSTER_NAME }}
 
-      - name: Install Helm
-        uses: azure/setup-helm@v5
-        with:
-          version: "v3.17.3"
-
-      - name: Login to GitHub Container Registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u repowerednl --password-stdin
-
       - name: Deploy
         uses: helmfile/helmfile-action@v2
         with:
           helmfile-version: "v0.171.0"
+          helm-version: "v3.17.3"
           helm-plugins: https://github.com/databus23/helm-diff
           helmfile-args: >-
             -f deployment/${{ inputs.environment }}/helmfile.yaml apply
             --concurrency 0
             --state-values-set dockerImageTag=${{ inputs.docker_image_tag }}
+            --state-values-set ghcrToken=${{ secrets.GITHUB_TOKEN }}
             ${{ inputs.selector != '' && format('--selector {0}', inputs.selector) || '' }}
 
       - name: Deployment status summary

--- a/.github/workflows/deploy-helmfile-kubernetes.yml
+++ b/.github/workflows/deploy-helmfile-kubernetes.yml
@@ -1,0 +1,67 @@
+name: Deploy
+
+on:
+  workflow_call:
+    inputs:
+      docker_image_tag:
+        type: string
+        required: true
+      environment:
+        type: string
+        required: true
+      selector:
+        type: string
+        required: false
+        description: "Helmfile label selector to target specific releases, e.g. 'name=api'"
+    secrets:
+      digital_ocean_access_token:
+        required: true
+
+jobs:
+  deploy-helmfile:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    permissions:
+      packages: read
+      contents: read
+    steps:
+      - name: Checkout ${{ github.repository }}
+        uses: actions/checkout@v4
+
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.digital_ocean_access_token }}
+
+      - name: Save DigitalOcean kubeconfig with short-lived credentials
+        env:
+          expiry-seconds: ${{ vars.KUBE_CRED_EXPIRY_SECOND || 300 }}
+        run: doctl kubernetes cluster kubeconfig save --expiry-seconds ${{ env.expiry-seconds }} ${{ vars.CLUSTER_NAME }}
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4.3.0
+
+      - name: Login to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u repowerednl --password-stdin
+
+      - name: Deploy
+        uses: helmfile/helmfile-action@v2
+        with:
+          helmfile-version: "v0.171.0"
+          helm-plugins: https://github.com/databus23/helm-diff
+          helmfile-args: >-
+            -f deployment/${{ inputs.environment }}/helmfile.yaml apply
+            ${{ inputs.selector != '' && format('--selector {0}', inputs.selector) || '' }}
+        env:
+          DOCKER_IMAGE_TAG: ${{ inputs.docker_image_tag }}
+          ENVIRONMENT: ${{ inputs.environment }}
+
+      - name: Deployment status summary
+        if: always()
+        continue-on-error: true
+        run: |
+          echo "## Helmfile Status" >> $GITHUB_STEP_SUMMARY
+          helmfile -f deployment/${{ inputs.environment }}/helmfile.yaml status >> $GITHUB_STEP_SUMMARY
+          echo "Image tag: ${{ inputs.docker_image_tag }}" >> $GITHUB_STEP_SUMMARY
+        env:
+          ENVIRONMENT: ${{ inputs.environment }}

--- a/.github/workflows/deploy-helmfile-kubernetes.yml
+++ b/.github/workflows/deploy-helmfile-kubernetes.yml
@@ -11,8 +11,8 @@ on:
         required: true
       selector:
         type: string
-        required: false
-        description: "Release name to target a specific release, e.g. 'api'. Leave empty to deploy all releases."
+        required: true
+        description: "Release name to deploy, e.g. 'api'. Must match a release name in helmfile.yaml.gotmpl."
     secrets:
       digital_ocean_access_token:
         required: true
@@ -59,7 +59,7 @@ jobs:
           helmfile-args: >-
             -f deployment/helmfile.yaml.gotmpl apply
             --concurrency 0
-            ${{ inputs.selector != '' && format('--selector name={0}', inputs.selector) || '' }}
+            --selector name=${{ inputs.selector }}
 
       - name: Deployment status summary
         if: success()
@@ -71,13 +71,13 @@ jobs:
           echo "<details><summary>Release status</summary>" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          helmfile -f deployment/helmfile.yaml.gotmpl ${{ inputs.selector != '' && format('--selector name={0}', inputs.selector) || '' }} status >> $GITHUB_STEP_SUMMARY 2>&1 || true
+          helmfile -f deployment/helmfile.yaml.gotmpl --selector name=${{ inputs.selector }} status >> $GITHUB_STEP_SUMMARY 2>&1 || true
           echo '```' >> $GITHUB_STEP_SUMMARY
           echo "</details>" >> $GITHUB_STEP_SUMMARY
 
       - name: Deployment failure summary
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           DOCKER_IMAGE_TAG: ${{ inputs.docker_image_tag }}
           ENVIRONMENT: ${{ inputs.environment }}
@@ -89,80 +89,45 @@ jobs:
               return (match?.[1] ?? raw).trim();
             };
 
-            const parseReleases = stdout => stdout.split('\n').slice(1).filter(Boolean).map(line => {
-              const [name, ns] = line.trim().split(/\s+/);
-              return { name, ns };
-            }).filter(r => r.name && r.ns);
-
-            const baseArgs = ['-f', 'deployment/helmfile.yaml.gotmpl'];
-            const selectorArgs = process.env.SELECTOR ? ['--selector', `name=${process.env.SELECTOR}`] : [];
-            const helmfileArgs = cmd => [...baseArgs, cmd, ...selectorArgs];
+            const helmfileArgs = cmd => [
+              '-f', 'deployment/helmfile.yaml.gotmpl',
+              cmd,
+              '--selector', `name=${process.env.SELECTOR}`
+            ];
 
             const failedStatuses = ['failed', 'pending-install', 'pending-upgrade', 'pending-rollback'];
             const statusIcon = s => s === 'deployed' ? '✅' : failedStatuses.includes(s) ? '❌' : '⚠️';
 
             await core.summary.addHeading('❌ Deployment failed', 2);
 
-            // Get release list — works even when templates/values fail
-            const list = await exec.getExecOutput('helmfile', helmfileArgs('list'), {
-              ignoreReturnCode: true, silent: true
-            });
-            const releases = parseReleases(list.stdout);
-
             // Detect config/template errors
             const tmpl = await exec.getExecOutput('helmfile', helmfileArgs('template'), {
               ignoreReturnCode: true, silent: true
             });
             if (tmpl.exitCode !== 0) {
-              core.summary
+              await core.summary
                 .addHeading('Configuration error', 3)
-                .addQuote('The chart could not be rendered or processed. Check your helmfile.yaml.gotmpl or helm values.yaml file(s).');
-
-              if (releases.length > 1) {
-                // Check each release individually to show which ones fail
-                const perRelease = await Promise.all(releases.map(async ({ name, ns }) => {
-                  const r = await exec.getExecOutput('helmfile', [
-                    ...baseArgs, 'template', '--selector', `name=${name}`
-                  ], { ignoreReturnCode: true, silent: true });
-                  return { name, ns, ok: r.exitCode === 0, error: extractError(r.stderr || r.stdout) };
-                }));
-
-                core.summary.addTable([
-                  [{data: 'Release', header: true}, {data: 'Namespace', header: true}, {data: 'Status', header: true}],
-                  ...perRelease.map(({ name, ns, ok }) => [name, ns, ok ? '✅ ok' : '❌ error'])
-                ]);
-
-                for (const { name, error } of perRelease.filter(r => !r.ok)) {
-                  core.summary.addDetails(name, `\n\n\`\`\`\n${error}\n\`\`\`\n`);
-                }
-              } else {
-                core.summary.addCodeBlock(extractError(tmpl.stderr || tmpl.stdout));
-              }
-
-              await core.summary.write();
+                .addQuote('The chart could not be rendered or processed. Check your helmfile.yaml.gotmpl or helm values.yaml file(s).')
+                .addCodeBlock(extractError(tmpl.stderr || tmpl.stdout))
+                .write();
               return;
             }
 
-            // Cluster installation error — fetch helm status per release in parallel
-            const statuses = await Promise.all(releases.map(async ({ name, ns }) => {
-              const result = await exec.getExecOutput('helm', ['status', name, '-n', ns], {
-                ignoreReturnCode: true, silent: true
-              });
-              const output = result.stdout || result.stderr;
-              const status = output.match(/^STATUS:\s+(\S+)/m)?.[1] ?? 'not found';
-              return { name, ns, status, output };
-            }));
+            // Cluster installation error — get release namespace then fetch helm status
+            const list = await exec.getExecOutput('helmfile', helmfileArgs('list'), {
+              ignoreReturnCode: true, silent: true
+            });
+            const [name, ns] = list.stdout.split('\n').slice(1).filter(Boolean)[0]?.trim().split(/\s+/) ?? [];
 
-            core.summary
+            const result = await exec.getExecOutput('helm', ['status', name, '-n', ns], {
+              ignoreReturnCode: true, silent: true
+            });
+            const output = result.stdout || result.stderr;
+            const status = output.match(/^STATUS:\s+(\S+)/m)?.[1] ?? 'not found';
+
+            await core.summary
               .addHeading('Cluster installation error', 3)
               .addQuote('Templates rendered successfully — the error occurred during installation on the cluster.')
-              .addTable([
-                [{data: 'Release', header: true}, {data: 'Namespace', header: true}, {data: 'Status', header: true}],
-                ...statuses.map(({ name, ns, status }) => [name, ns, `${statusIcon(status)} ${status}`])
-              ]);
-
-            for (const { name, output } of statuses) {
-              core.summary.addDetails(name, `\n\n\`\`\`\n${output.trim()}\n\`\`\`\n`);
-            }
-
-            await core.summary.write();
+              .addRaw(`**${statusIcon(status)} ${name}** — \`${status}\`\n\n`)
+              .addDetails('helm status output', `\n\n\`\`\`\n${output.trim()}\n\`\`\`\n`)
+              .write();

--- a/configuration-files/helmfile/helmfile.yaml
+++ b/configuration-files/helmfile/helmfile.yaml
@@ -17,6 +17,6 @@ releases:
       - values_my-app.yml
     set:
       - name: image
-        value: '{{ .Values.dockerImageTag }}'
+        value: {{ requiredEnv "DOCKER_IMAGE_TAG" }}
 
   # Add more releases following the same pattern

--- a/configuration-files/helmfile/helmfile.yaml
+++ b/configuration-files/helmfile/helmfile.yaml
@@ -17,6 +17,6 @@ releases:
       - values_my-app.yml
     set:
       - name: image
-        value: {{ requiredEnv "DOCKER_IMAGE_TAG" }}
+        value: '{{ requiredEnv "DOCKER_IMAGE_TAG" }}'
 
   # Add more releases following the same pattern

--- a/configuration-files/helmfile/helmfile.yaml
+++ b/configuration-files/helmfile/helmfile.yaml
@@ -6,7 +6,7 @@ helmDefaults:
   cleanupOnFail: true
   timeout: 600
   wait: true
-  forceUpgrade: true
+  force: true
 
 releases:
   - name: my-app
@@ -17,6 +17,6 @@ releases:
       - values_my-app.yml
     set:
       - name: image
-        value: {{ requiredEnv "DOCKER_IMAGE_TAG" }}
+        value: '{{ .Values.dockerImageTag }}'
 
   # Add more releases following the same pattern

--- a/configuration-files/helmfile/helmfile.yaml
+++ b/configuration-files/helmfile/helmfile.yaml
@@ -1,0 +1,22 @@
+# Copy this file to deployment/<environment>/helmfile.yaml in your app repo.
+# All releases for this environment are declared here.
+
+helmDefaults:
+  atomic: true
+  cleanupOnFail: true
+  timeout: 600
+  wait: true
+  forceUpgrade: true
+
+releases:
+  - name: my-app
+    namespace: my-namespace
+    chart: oci://ghcr.io/repowerednl/helm-charts/deployment
+    version: "1.0.1"  # update when upgrading the chart
+    values:
+      - values_my-app.yml
+    set:
+      - name: image
+        value: {{ requiredEnv "DOCKER_IMAGE_TAG" }}
+
+  # Add more releases following the same pattern

--- a/configuration-files/helmfile/helmfile.yaml
+++ b/configuration-files/helmfile/helmfile.yaml
@@ -1,6 +1,12 @@
 # Copy this file to deployment/<environment>/helmfile.yaml in your app repo.
 # All releases for this environment are declared here.
 
+registries:
+  - name: ghcr
+    url: ghcr.io
+    username: repowerednl
+    password: '{{ .Values.ghcrToken }}'
+
 helmDefaults:
   atomic: true
   cleanupOnFail: true

--- a/configuration-files/helmfile/helmfile.yaml
+++ b/configuration-files/helmfile/helmfile.yaml
@@ -1,12 +1,6 @@
 # Copy this file to deployment/<environment>/helmfile.yaml in your app repo.
 # All releases for this environment are declared here.
 
-registries:
-  - name: ghcr
-    url: ghcr.io
-    username: '{{ requiredEnv "GHCR_USERNAME" }}'
-    password: '{{ requiredEnv "GHCR_PASSWORD" }}'
-
 helmDefaults:
   atomic: true
   cleanupOnFail: true

--- a/configuration-files/helmfile/helmfile.yaml
+++ b/configuration-files/helmfile/helmfile.yaml
@@ -4,8 +4,8 @@
 registries:
   - name: ghcr
     url: ghcr.io
-    username: repowerednl
-    password: '{{ .Values.ghcrToken }}'
+    username: '{{ requiredEnv "GHCR_USERNAME" }}'
+    password: '{{ requiredEnv "GHCR_PASSWORD" }}'
 
 helmDefaults:
   atomic: true

--- a/configuration-files/helmfile/helmfile.yaml.gotmpl
+++ b/configuration-files/helmfile/helmfile.yaml.gotmpl
@@ -1,11 +1,27 @@
 # Copy this file to deployment/helmfile.yaml.gotmpl in your app repo. All releases are declared here
 
 helmDefaults:
-  atomic: true
-  cleanupOnFail: true
-  timeout: 600
-  wait: true
-  force: true
+# atomic: ensures all-or-nothing deployments; automatically rolls back on failure
+atomic: true
+# cleanupOnFail: removes resources created during a failed deployment attempt
+cleanupOnFail: true
+# timeout: maximum time (seconds) for a deployment to finish
+timeout: 600
+# wait: waits for all resources to be ready before marking the release as successful
+wait: true
+# force: forces resource updates through delete/recreate if needed (use with caution)
+force: true
+# createNamespace: automatically creates the namespace if it doesn't exist
+createNamespace: true
+# recreatePods: forces pods to be recreated during updates
+recreatePods: false
+# historyMax: maximum number of release revisions to keep (0 = unlimited)
+historyMax: 10
+# verify: verify the chart before installing/upgrading (requires signed charts)
+verify: false
+# skipDeps: skip running 'helm dependency update' before install/upgrade
+skipDeps: false
+
 
 releases:
   - name: my-app

--- a/configuration-files/helmfile/helmfile.yaml.gotmpl
+++ b/configuration-files/helmfile/helmfile.yaml.gotmpl
@@ -1,5 +1,4 @@
-# Copy this file to deployment/<environment>/helmfile.yaml.gotmpl in your app repo.
-# All releases for this environment are declared here.
+# Copy this file to deployment/helmfile.yaml.gotmpl in your app repo. All releases are declared here
 
 helmDefaults:
   atomic: true
@@ -14,7 +13,7 @@ releases:
     chart: oci://ghcr.io/repowerednl/helm-charts/deployment
     version: "1.0.1"  # update when upgrading the chart
     values:
-      - values_my-app.yml
+      - '{{ requiredEnv "ENVIRONMENT" }}/values_my-app.yml'
     set:
       - name: image
         value: '{{ requiredEnv "DOCKER_IMAGE_TAG" }}'

--- a/configuration-files/helmfile/helmfile.yaml.gotmpl
+++ b/configuration-files/helmfile/helmfile.yaml.gotmpl
@@ -1,4 +1,4 @@
-# Copy this file to deployment/<environment>/helmfile.yaml in your app repo.
+# Copy this file to deployment/<environment>/helmfile.yaml.gotmpl in your app repo.
 # All releases for this environment are declared here.
 
 helmDefaults:

--- a/workflow-templates/tag-docker-helmfile-kube.properties.json
+++ b/workflow-templates/tag-docker-helmfile-kube.properties.json
@@ -1,0 +1,10 @@
+{
+    "name": "Tag, Docker, Helmfile and Kubernetes deploy",
+    "description": "Create and publish a SemVer GitHub Tag, build the Docker image, use Helmfile to declaratively deploy all releases to Kubernetes",
+    "iconName": "octicon container",
+    "categories": ["Repowered"],
+    "filePatterns": [
+        "(.*\\/)?Dockerfile(\\.{1}[^.].*)?",
+        "^deployment\\/.*\\/helmfile\\.ya?ml$"
+    ]
+}

--- a/workflow-templates/tag-docker-helmfile-kube.properties.json
+++ b/workflow-templates/tag-docker-helmfile-kube.properties.json
@@ -5,6 +5,6 @@
     "categories": ["Repowered"],
     "filePatterns": [
         "(.*\\/)?Dockerfile(\\.{1}[^.].*)?",
-        "^deployment\\/.*\\/helmfile\\.ya?ml$"
+        "^deployment\\/helmfile\\.ya?ml(\\.gotmpl)?$"
     ]
 }

--- a/workflow-templates/tag-docker-helmfile-kube.yml
+++ b/workflow-templates/tag-docker-helmfile-kube.yml
@@ -60,11 +60,15 @@ jobs:
       infisical_client_project_id: ${{ secrets.INFISICAL_PROJECT_ID }}
 
   deploy:
+    strategy:
+      matrix:
+        selector: [my-app]  # add one entry per release name in deployment/helmfile.yaml.gotmpl
+      fail-fast: false
     uses: repowerednl/.github/.github/workflows/deploy-helmfile-kubernetes.yml@main
     needs: [ docker, run-migrations ]
     with:
       docker_image_tag: ${{ needs.docker.outputs.image_tag }}
       environment: ${{ needs.docker.outputs.environment }}
-      # selector: "name=api"  # Optional: target a specific release defined in the helmfile
+      selector: ${{ matrix.selector }}
     secrets:
       digital_ocean_access_token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}

--- a/workflow-templates/tag-docker-helmfile-kube.yml
+++ b/workflow-templates/tag-docker-helmfile-kube.yml
@@ -1,0 +1,70 @@
+name: GitHub Tag, Docker publish build, Helmfile deployment
+
+on:
+  push:
+    branches:
+      - main
+  workflow_run:
+    workflows:
+!      - # The actual name of your TEST workflow (example: Run Pytest with Coverage, Check the Django Migration and run the Sonar Analysis)
+    types:
+      - completed
+    branches:
+      - dev
+      - hotfix**
+  pull_request:
+    types:
+      - labeled
+
+run-name: Deploy branch ${{ github.event.workflow_run.head_branch || github.head_ref || github.ref_name }} by @${{ github.actor }}
+
+jobs:
+  tag:
+    permissions:
+      contents: write
+    uses: repowerednl/.github/.github/workflows/generate-github-tag.yml@main
+
+  create-release:
+    needs: tag
+    uses: repowerednl/.github/.github/workflows/release-notes-generator.yml@main
+    with:
+      tag: ${{ needs.tag.outputs.tag }}
+
+  github-environment:
+    permissions:
+      pull-requests: read
+    uses: repowerednl/.github/.github/workflows/determine-environment.yml@main
+
+  docker:
+    uses: repowerednl/.github/.github/workflows/docker-build-and-push.yml@main
+    needs: [ tag, github-environment ]
+    with:
+      tag: ${{ needs.tag.outputs.tag }}
+      docker_hub_username: ${{ vars.DOCKER_HUB_USERNAME }}
+      environment: ${{ needs.github-environment.outputs.environment }}
+    secrets:
+      docker_hub_access_token: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+#   TODO(REP-2945): Move this step to the repository infra
+#   Should only be active for apps with a database (add job to 'needs' in deploy)
+  run-migrations:
+    uses: repowerednl/.github/.github/workflows/run-kube-migration.yml@main
+    needs: [ tag, github-environment ]
+    with:
+      tag: ${{ needs.tag.outputs.tag }}
+      environment: ${{ needs.github-environment.outputs.environment }}
+    secrets:
+      digital_ocean_access_token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+      infisical_client_id: ${{ secrets.INFISICAL_CLIENT_ID }}
+      infisical_client_client_secret: ${{ secrets.INFISICAL_CLIENT_SECRET }}
+      infisical_client_project_id: ${{ secrets.INFISICAL_PROJECT_ID }}
+
+  deploy:
+    uses: repowerednl/.github/.github/workflows/deploy-helmfile-kubernetes.yml@main
+    needs: [ docker, run-migrations ]
+    with:
+      docker_image_tag: ${{ needs.docker.outputs.image_tag }}
+      environment: ${{ needs.docker.outputs.environment }}
+      # selector: "name=api"  # Optional: target a specific release defined in the helmfile
+    secrets:
+      digital_ocean_access_token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary
Currently, we are using custom bash scripts which is not what we want. We try to focus on using more mature actions and/or tools. This PR is to use this great tool+action: https://helmfile.readthedocs.io/en/latest/

Key benefits:

- No more JSON matrix string stuff (very error prone)
- helmfile sync with --selector handles multiple deployments (like the 4 workers) case natively and in parallel
- Stuck release recovery is gone — helmfile detects and handles pending states itself
- The helmfile per environment gives single source of truth for what's deployed where (currently that's implied)

### TODO

- [x] Test workflow: https://github.com/repowerednl/workflow-tests/actions/runs/24722664653 (includes faulty deployments to test error summary)