### PR TITLE
Upgrade checkout

### DIFF
--- a/.github/workflows/bump-package-json.yml
+++ b/.github/workflows/bump-package-json.yml
@@ -33,7 +33,7 @@ jobs:
           private-key: ${{ secrets.private-key }}
 
       - name: Checkout code on dev
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref_name }}
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/deploy-helm-kubernetes.yml
+++ b/.github/workflows/deploy-helm-kubernetes.yml
@@ -57,7 +57,7 @@ jobs:
         uses: azure/setup-helm@v4.3.0
 
       - name: Checkout ${{ github.repository }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
 

--- a/.github/workflows/deploy-sphinx-documentation.yml
+++ b/.github/workflows/deploy-sphinx-documentation.yml
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: (Cached) Python and Poetry
         id: cache

--- a/.github/workflows/deploy-uv-sphinx-documentation.yml
+++ b/.github/workflows/deploy-uv-sphinx-documentation.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
 
       - name: UV and Python Setup

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -87,7 +87,7 @@ jobs:
     environment: ${{ inputs.environment }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       #  Log in to the desired docker hub space
       - name: Login to Docker Hub

--- a/.github/workflows/generate-github-tag.yml
+++ b/.github/workflows/generate-github-tag.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       # Checkout the repository with all commit history
       - name: Checkout ${{ github.repository }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: '0'
           ref: ${{ github.event.workflow_run.head_sha }}

--- a/.github/workflows/python-test-coverage-simple.yml
+++ b/.github/workflows/python-test-coverage-simple.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 

--- a/.github/workflows/python-test-coverage.yml
+++ b/.github/workflows/python-test-coverage.yml
@@ -80,7 +80,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
@@ -127,7 +127,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: (Cached) Python and Poetry
         uses: repowerednl/.github/composite-actions/python-poetry-cache@main

--- a/.github/workflows/python-uv-test-coverage-simple.yml
+++ b/.github/workflows/python-uv-test-coverage-simple.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 

--- a/.github/workflows/release-notes-generator.yml
+++ b/.github/workflows/release-notes-generator.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout tagged commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release-pypi-package.yml
+++ b/.github/workflows/release-pypi-package.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: (Cached) Python and Poetry
       id: cache

--- a/.github/workflows/release-uv-pypi-package.yml
+++ b/.github/workflows/release-uv-pypi-package.yml
@@ -26,7 +26,7 @@ jobs:
       UV_INDEX_REPOWERED_PASSWORD: ${{ secrets.private_pypi_password }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: UV and Python Setup
       id: cache

--- a/.github/workflows/yarn-check-lint-prettier-test-publish.yml
+++ b/.github/workflows/yarn-check-lint-prettier-test-publish.yml
@@ -38,7 +38,7 @@ jobs:
       PACKAGES_AUTH_TOKEN: ${{ secrets.packages_auth_token }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .idea/
+
+# MemPalace per-project files (issue #185)
+mempalace.yaml
+entities.json


### PR DESCRIPTION
Version bump

#patch: checkout action v4/v5 -> v6

##  Summary

Upgrade actions/checkout from v4/v5 to v6 across all reusable workflows.

### Changed workflows (13 files):
  - v4 → v6: bump-package-json, deploy-helm-kubernetes, deploy-sphinx-documentation, docker-build-and-push, generate-github-tag, python-test-coverage, python-test-coverage-simple, release-notes-generator, release-pypi-package,
  yarn-check-lint-prettier-test-publish
  - v5 → v6: deploy-uv-sphinx-documentation, python-uv-test-coverage-simple, release-uv-pypi-package

### What changed in v6:
  - Credentials are now stored in a separate git config file (via includeIf) instead of .git/config — security improvement, no behavioral change
  - Improved worktree support for persist-credentials
  - Tag fetching and SHA-256 object fixes
  
  No input schema changes; all existing inputs (token, fetch-depth, ref) work identically.

## Checks
Most important templates tested for all branch flows. See https://github.com/repowerednl/workflow-tests/pull/46 until https://github.com/repowerednl/workflow-tests/pull/53 (so 7 PRs in total)

Co-authored by @ozhanaydar 