### PR TITLE
fix branch detection for tag creation + cleanup pytest template

### DIFF
--- a/.github/workflows/generate-github-tag.yml
+++ b/.github/workflows/generate-github-tag.yml
@@ -34,8 +34,8 @@ jobs:
         with:
           script: |
             const branch = context.payload.workflow_run?.head_branch
-              ?? process.env.GITHUB_HEAD_REF
-              ?? process.env.GITHUB_REF.split('/').pop();
+              || process.env.GITHUB_HEAD_REF
+              || process.env.GITHUB_REF?.split('/').pop();
             const commitMsg = context.payload.workflow_run?.head_commit?.message ?? '';
             const label = context.payload.label?.name ?? '';
             const prHead = context.payload.pull_request?.head?.ref ?? '';

--- a/workflow-templates/pytest-quality-coverage.properties.json
+++ b/workflow-templates/pytest-quality-coverage.properties.json
@@ -1,13 +1,12 @@
 {
-    "name": "Pytests, Django migration check and Sonar with test coverage",
-    "description": "Runs the python unit tests (pytests) with coverage, checks for django migrations and analyses the quality via sonarcloud",
+    "name": "Pytests and Sonar with test coverage",
+    "description": "Runs the python unit tests (pytests) with coverage and analyses the quality via sonarcloud",
     "iconName": "octicon check-circle",
     "categories": [
         "Repowered"
     ],
     "filePatterns": [
         ".*.py",
-        "poetry.lock",
         "uv.lock",
         "pyproject.toml"
     ]

--- a/workflow-templates/pytest-quality-coverage.yml
+++ b/workflow-templates/pytest-quality-coverage.yml
@@ -54,11 +54,10 @@ jobs:
       actions: read
     strategy:
       matrix:
-        uv_version: [ "1.8.4" ]
+        uv_version: [ "0.11.21" ]
     with:
       uv_version: ${{ matrix.uv_version }}
     secrets:
-      private_pypi_url: ${{ secrets.PRIVATE_PYPI_URL }}
       private_pypi_user: ${{ secrets.PRIVATE_PYPI_USER }}
       private_pypi_password: ${{ secrets.PRIVATE_PYPI_PASSWORD }}
 


### PR DESCRIPTION
 ## Version bump
  
  #patch

## Summary

  Two minor bug fixes:

  1. Fix branch detection in generate-github-tag always creating prereleases on main
  When triggered via workflow_call from a push to main, GITHUB_HEAD_REF is set to an empty string. The result was an empty branch name, causing every tag on main to be created as a prerelease.

  2. Update pytest-quality-coverage workflow template
  - Removed outdated poetry.lock file pattern (project uses uv)
  - Updated uv_version to 0.11.21 (1.8.4 does not really exist)
  - Removed private_pypi_url secret (no longer needed)
  - Updated name/description to drop the Django migration check reference

## Checks
- [ ] succesfull workflow run of branch merges: todo