### PR TITLE
Upgrades remaining actions: github-script v9, setup-node v5, create-github-app-token v3, sonarqube-scan-action v6

### DIFF
--- a/.github/workflows/bump-package-json.yml
+++ b/.github/workflows/bump-package-json.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ inputs.app-id }}
+          client-id: ${{ inputs.app-id }}
           private-key: ${{ secrets.private-key }}
 
       - name: Checkout code on dev
@@ -39,7 +39,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node_version }}
 

--- a/.github/workflows/bump-package-json.yml
+++ b/.github/workflows/bump-package-json.yml
@@ -26,7 +26,7 @@ jobs:
       contents: write
     steps:
       - name: Generate GitHub App token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ inputs.app-id }}
@@ -39,7 +39,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ inputs.node_version }}
 

--- a/.github/workflows/classify-pr-event.yml
+++ b/.github/workflows/classify-pr-event.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Detect merge sync
         id: detect
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             // Returns { value, reason }; biased to 'false' (run tests) when unsure.

--- a/.github/workflows/quality-control-sonar.yml
+++ b/.github/workflows/quality-control-sonar.yml
@@ -27,7 +27,7 @@ jobs:
           name: ${{ inputs.coverage_report_name }}
 
       - name: SonarCloud analysis
-        uses: SonarSource/sonarqube-scan-action@v4
+        uses: SonarSource/sonarqube-scan-action@v8
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/yarn-check-lint-prettier-test-publish.yml
+++ b/.github/workflows/yarn-check-lint-prettier-test-publish.yml
@@ -43,7 +43,7 @@ jobs:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: Setup Node.js with yarn cache
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ inputs.node_version }}
           cache: 'yarn'

--- a/.github/workflows/yarn-check-lint-prettier-test-publish.yml
+++ b/.github/workflows/yarn-check-lint-prettier-test-publish.yml
@@ -43,7 +43,7 @@ jobs:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: Setup Node.js with yarn cache
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node_version }}
           cache: 'yarn'


### PR DESCRIPTION
Version bump

#patch

## Summary

Upgrades remaining actions to their latest versions across all reusable workflows.

| File | Change |
|---|---|
| `classify-pr-event.yml` | `github-script@v8 → v9` |
| `bump-package-json.yml` | `create-github-app-token@v2 → v3`, `app-id` → `client-id`, `setup-node@v4 → v6` |
| `yarn-check-lint-prettier-test-publish.yml` | `setup-node@v4 → v6` |
| `quality-control-sonar.yml` | `sonarqube-scan-action@v4 → v6` |

---

### What changed in `github-script@v8 → v9`
- ESM migration: `require('@actions/github')` no longer works.
- `getOctokit` is now an injected function parameter.

`classify-pr-event.yml` uses only the injected `github` and `core` objects — none of the breaking changes apply.

---

### What changed in `create-github-app-token@v2 → v3`
- Node.js 24 runtime.
- Custom proxy handling removed — if using `HTTP_PROXY`/`HTTPS_PROXY`, you must now also set `NODE_USE_ENV_PROXY=1`. GitHub-hosted runners don't use proxies, so this does not apply.
- `app-id` input deprecated in favour of `client-id` — updated accordingly.
- Requires Actions Runner v2.327.1+ on self-hosted runners.

---

### What changed in `setup-node@v4 → v6`
- v5: Dropped Node.js 16 runner support. `ubuntu-latest` uses Node 20+, so this does not apply.
- v6: Node.js 24 runtime upgrade, dependency updates.
- No input/output schema changes across either version.

---

### What changed in `sonarqube-scan-action@v4 → v6`
- v4 and v5 are deprecated with a known security vulnerability — upgrade to v6 is strongly recommended.
- v6 rewrote the action from Bash to JS to prevent command-line injection. The `args` input is now parsed differently.

`quality-control-sonar.yml` passes no `args` — only env vars (`SONAR_TOKEN`, `GITHUB_TOKEN`) — so the breaking change does not apply.

---

## Testing

Tested via workflow-tests on branch `download-upload`.

**sonarqube-scan-action@v6 + download-artifact@v8:**
https://github.com/repowerednl/workflow-tests/actions/runs/28010711409

**setup-node@v6 (yarn workflow):**
https://github.com/repowerednl/workflow-tests/actions/runs/28012472734

**github-script@v9 (classify-pr-event):**
https://github.com/repowerednl/workflow-tests/actions/runs/28014172922

**create-github-app-token@v3 (client-id parameter):**
https://github.com/repowerednl/workflow-tests/actions/runs/28022454200/job/82941885680

## Jira ticket

IN-312

## Checks
- [ ] I have added unit tests
- [x] I have tested this locally