### PR TITLE
In 312 final worklfow upgrades

### DIFF
--- a/.github/workflows/bump-package-json.yml
+++ b/.github/workflows/bump-package-json.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ inputs.app-id }}
+          client-id: ${{ inputs.app-id }}
           private-key: ${{ secrets.private-key }}
 
       - name: Checkout code on dev
@@ -39,7 +39,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node_version }}
 

--- a/.github/workflows/bump-package-json.yml
+++ b/.github/workflows/bump-package-json.yml
@@ -26,7 +26,7 @@ jobs:
       contents: write
     steps:
       - name: Generate GitHub App token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ inputs.app-id }}
@@ -39,7 +39,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ inputs.node_version }}
 

--- a/.github/workflows/bump-package-json.yml
+++ b/.github/workflows/bump-package-json.yml
@@ -33,7 +33,7 @@ jobs:
           private-key: ${{ secrets.private-key }}
 
       - name: Checkout code on dev
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.ref_name }}
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/classify-pr-event.yml
+++ b/.github/workflows/classify-pr-event.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Detect merge sync
         id: detect
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             // Returns { value, reason }; biased to 'false' (run tests) when unsure.

--- a/.github/workflows/deploy-helm-kubernetes.yml
+++ b/.github/workflows/deploy-helm-kubernetes.yml
@@ -44,7 +44,7 @@ jobs:
           echo "VALUES_FILEPATH=deployment/${{ inputs.environment }}/$filename" >> $GITHUB_OUTPUT
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2.5.2
+        uses: digitalocean/action-doctl@v2
         with:
           token: ${{ secrets.digital_ocean_access_token }}
 

--- a/.github/workflows/deploy-helm-kubernetes.yml
+++ b/.github/workflows/deploy-helm-kubernetes.yml
@@ -57,7 +57,7 @@ jobs:
         uses: azure/setup-helm@v4.3.0
 
       - name: Checkout ${{ github.repository }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 2
 

--- a/.github/workflows/deploy-helm-kubernetes.yml
+++ b/.github/workflows/deploy-helm-kubernetes.yml
@@ -44,7 +44,7 @@ jobs:
           echo "VALUES_FILEPATH=deployment/${{ inputs.environment }}/$filename" >> $GITHUB_OUTPUT
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@v2.5.2
         with:
           token: ${{ secrets.digital_ocean_access_token }}
 

--- a/.github/workflows/deploy-helmfile-kubernetes.yml
+++ b/.github/workflows/deploy-helmfile-kubernetes.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2.5.1
+        uses: digitalocean/action-doctl@v2
         with:
           token: ${{ secrets.digital_ocean_access_token }}
 

--- a/.github/workflows/deploy-helmfile-kubernetes.yml
+++ b/.github/workflows/deploy-helmfile-kubernetes.yml
@@ -31,7 +31,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout ${{ github.repository }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install doctl
         uses: digitalocean/action-doctl@v2

--- a/.github/workflows/deploy-helmfile-kubernetes.yml
+++ b/.github/workflows/deploy-helmfile-kubernetes.yml
@@ -52,7 +52,7 @@ jobs:
         run: helm registry login ghcr.io --username repowerednl --password ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy
-        uses: helmfile/helmfile-action@v2.4.3
+        uses: helmfile/helmfile-action@v2.4.5
         env:
           DOCKER_IMAGE_TAG: ${{ inputs.docker_image_tag }}
           ENVIRONMENT: ${{ inputs.environment }}

--- a/.github/workflows/deploy-sphinx-documentation.yml
+++ b/.github/workflows/deploy-sphinx-documentation.yml
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: (Cached) Python and Poetry
         id: cache

--- a/.github/workflows/deploy-uv-sphinx-documentation.yml
+++ b/.github/workflows/deploy-uv-sphinx-documentation.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
 
       - name: UV and Python Setup

--- a/.github/workflows/deploy-verify-kubernetes.yml
+++ b/.github/workflows/deploy-verify-kubernetes.yml
@@ -27,7 +27,7 @@ jobs:
         container_name: ${{ fromJSON(inputs.container_names) }}
     steps:
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@v2.5.2
         with:
           token: ${{ secrets.digital_ocean_access_token }}
 

--- a/.github/workflows/deploy-verify-kubernetes.yml
+++ b/.github/workflows/deploy-verify-kubernetes.yml
@@ -27,7 +27,7 @@ jobs:
         container_name: ${{ fromJSON(inputs.container_names) }}
     steps:
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2.5.2
+        uses: digitalocean/action-doctl@v2
         with:
           token: ${{ secrets.digital_ocean_access_token }}
 

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -87,7 +87,7 @@ jobs:
     environment: ${{ inputs.environment }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       #  Log in to the desired docker hub space
       - name: Login to Docker Hub

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -91,14 +91,14 @@ jobs:
 
       #  Log in to the desired docker hub space
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ inputs.docker_hub_username }}
           password: ${{ secrets.docker_hub_access_token }}
 
       # Build the Dockerfile(s) with the image tag in the correct format and push to the hub
       - name: Build '${{ inputs.dockerfile_name }}' and push with tag '${{ inputs.tag }}'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile_name }}

--- a/.github/workflows/generate-github-tag.yml
+++ b/.github/workflows/generate-github-tag.yml
@@ -72,7 +72,7 @@ jobs:
       # Automatically create and push tag with the latest SemVer formatted version.
       - name: Generate and push GitHub tag
         id: github-tag
-        uses: anothrNick/github-tag-action@1.71.0 # (7/5/25) Pinned version needed: https://github.com/anothrNick/github-tag-action/issues/341
+        uses: anothrNick/github-tag-action@1.75.0 # (7/5/25) Pinned version needed: https://github.com/anothrNick/github-tag-action/issues/341
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true

--- a/.github/workflows/generate-github-tag.yml
+++ b/.github/workflows/generate-github-tag.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       # Checkout the repository with all commit history
       - name: Checkout ${{ github.repository }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: '0'
           ref: ${{ github.event.workflow_run.head_sha }}

--- a/.github/workflows/prod-target-sync.yml
+++ b/.github/workflows/prod-target-sync.yml
@@ -81,7 +81,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install PostgreSQL 17 Client
         run: |

--- a/.github/workflows/python-test-coverage-simple.yml
+++ b/.github/workflows/python-test-coverage-simple.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 

--- a/.github/workflows/python-test-coverage.yml
+++ b/.github/workflows/python-test-coverage.yml
@@ -79,7 +79,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
@@ -126,7 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: (Cached) Python and Poetry
         uses: repowerednl/.github/composite-actions/python-poetry-cache@main

--- a/.github/workflows/python-uv-test-coverage-simple.yml
+++ b/.github/workflows/python-uv-test-coverage-simple.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 

--- a/.github/workflows/python-uv-test-coverage.yml
+++ b/.github/workflows/python-uv-test-coverage.yml
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: UV and Python Setup
         uses: repowerednl/.github/composite-actions/python-uv-cache@main

--- a/.github/workflows/quality-control-sonar.yml
+++ b/.github/workflows/quality-control-sonar.yml
@@ -16,7 +16,7 @@ jobs:
       github.event_name != 'pull_request' ||
       !(github.base_ref == 'main' && github.head_ref == 'dev')
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 

--- a/.github/workflows/quality-control-sonar.yml
+++ b/.github/workflows/quality-control-sonar.yml
@@ -27,7 +27,7 @@ jobs:
           name: ${{ inputs.coverage_report_name }}
 
       - name: SonarCloud analysis
-        uses: SonarSource/sonarqube-scan-action@v4
+        uses: SonarSource/sonarqube-scan-action@v8
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-notes-generator.yml
+++ b/.github/workflows/release-notes-generator.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Generate GitHub Release
-        uses: release-drafter/release-drafter@v6
+        uses: release-drafter/release-drafter@v7
         with:
           tag: ${{ inputs.tag }}
           name: ${{ github.event.repository.name }} ${{ inputs.tag }}

--- a/.github/workflows/release-notes-generator.yml
+++ b/.github/workflows/release-notes-generator.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout tagged commit
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release-pypi-package.yml
+++ b/.github/workflows/release-pypi-package.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: (Cached) Python and Poetry
       id: cache

--- a/.github/workflows/release-uv-pypi-package.yml
+++ b/.github/workflows/release-uv-pypi-package.yml
@@ -26,7 +26,7 @@ jobs:
       UV_INDEX_REPOWERED_PASSWORD: ${{ secrets.private_pypi_password }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: UV and Python Setup
       id: cache

--- a/.github/workflows/run-kube-migration.yml
+++ b/.github/workflows/run-kube-migration.yml
@@ -32,7 +32,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get -y install gettext-base
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@v2.5.2
         with:
           token: ${{ secrets.digital_ocean_access_token }}
 

--- a/.github/workflows/run-kube-migration.yml
+++ b/.github/workflows/run-kube-migration.yml
@@ -32,7 +32,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get -y install gettext-base
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2.5.2
+        uses: digitalocean/action-doctl@v2
         with:
           token: ${{ secrets.digital_ocean_access_token }}
 

--- a/.github/workflows/run-kube-migration.yml
+++ b/.github/workflows/run-kube-migration.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       
       - name: Install envsubst
         run: sudo apt-get update && sudo apt-get -y install gettext-base

--- a/.github/workflows/yarn-check-lint-prettier-test-publish.yml
+++ b/.github/workflows/yarn-check-lint-prettier-test-publish.yml
@@ -38,7 +38,7 @@ jobs:
       PACKAGES_AUTH_TOKEN: ${{ secrets.packages_auth_token }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 

--- a/.github/workflows/yarn-check-lint-prettier-test-publish.yml
+++ b/.github/workflows/yarn-check-lint-prettier-test-publish.yml
@@ -43,7 +43,7 @@ jobs:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: Setup Node.js with yarn cache
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ inputs.node_version }}
           cache: 'yarn'

--- a/.github/workflows/yarn-check-lint-prettier-test-publish.yml
+++ b/.github/workflows/yarn-check-lint-prettier-test-publish.yml
@@ -43,7 +43,7 @@ jobs:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: Setup Node.js with yarn cache
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node_version }}
           cache: 'yarn'

--- a/composite-actions/python-poetry-cache/action.yml
+++ b/composite-actions/python-poetry-cache/action.yml
@@ -39,13 +39,13 @@ runs:
   using: "composite"
   steps:
     - name: Setup python ${{ inputs.python_version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python_version }}
 
     - name: Load cache
       id: cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: ${{ inputs.file_paths_to_cache }}
         key: cache-python-${{ inputs.python_version }}-poetry-${{ inputs.poetry_version }}-${{ hashFiles('**/poetry.lock') }}
@@ -81,7 +81,7 @@ runs:
 
     - name: Save cache once
       if: ${{ inputs.save_cache == true && steps.cache.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: ${{ inputs.file_paths_to_cache }}
         key: cache-python-${{ inputs.python_version }}-poetry-${{ inputs.poetry_version }}-${{ hashFiles('**/poetry.lock') }}

--- a/composite-actions/python-uv-cache/action.yml
+++ b/composite-actions/python-uv-cache/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.2.0
       with:
         version: ${{ inputs.uv_version }}
         enable-cache: true


### PR DESCRIPTION
Version bump

#patch

## Summary

Upgrades the remaining actions to their latest versions across reusable workflows and composite actions.

| File | Change |
|---|---|
| `composite-actions/python-uv-cache/action.yml` | `astral-sh/setup-uv@v7` → `@v8.2.0` |
| `composite-actions/python-poetry-cache/action.yml` | `actions/setup-python@v5` → `@v6`, `cache/restore@v4` → `@v5`, `cache/save@v4` → `@v5` |
| `docker-build-and-push.yml` | `docker/login-action@v3` → `@v4`, `docker/build-push-action@v6` → `@v7`, `actions/checkout@v6` → `@v7` |
| `release-notes-generator.yml` | `release-drafter/release-drafter@v6` → `@v7`, `actions/checkout@v6` → `@v7` |
| `generate-github-tag.yml` | `anothrNick/github-tag-action@1.71.0` → `@1.75.0` |
| `deploy-helmfile-kubernetes.yml` | `helmfile/helmfile-action@v2.4.3` → `@v2.4.5`, `digitalocean/action-doctl` → `@v2` (major tag), `actions/checkout@v6` → `@v7` |
| `deploy-helm-kubernetes.yml` | `digitalocean/action-doctl` → `@v2` (major tag), `actions/checkout@v6` → `@v7` |
| `deploy-verify-kubernetes.yml` | `digitalocean/action-doctl` → `@v2` (major tag) |
| `run-kube-migration.yml` | `digitalocean/action-doctl` → `@v2` (major tag), `actions/checkout@v6` → `@v7` |

---

### What changed in `astral-sh/setup-uv@v7 → v8.2.0`
- Pinned to exact version `@v8.2.0` — the maintainer stopped publishing major/minor tags after v7, so floating `@v8` does not resolve.
- v8 has two breaking changes (verified against official release notes): (1) new `manifest-file` format — our workflow doesn't use `manifest-file`, not affected; (2) no more major/minor tags — already handled by the exact pin.

---

### What changed in `actions/checkout@v6 → v7`
- Node.js 24 runtime upgrade.
- No input/output schema changes.

---

### What changed in `actions/setup-python@v5 → v6` and `actions/cache@v4 → v5`
- Node.js 24 runtime upgrade.
- No input/output schema changes.
- Requires Actions Runner v2.327.1+ on self-hosted runners. GitHub-hosted runners auto-update past this version — not affected.

---

### What changed in `docker/login-action@v3 → v4` and `docker/build-push-action@v6 → v7`
- Node.js 24 runtime upgrade.
- `docker/build-push-action@v7` removed `DOCKER_BUILDKIT` and `COMPOSE_DOCKER_CLI_BUILD` env var injection. These env vars are not set or relied upon in `docker-build-and-push.yml` — not affected.
- No input/output schema changes.

---

### What changed in `release-drafter/release-drafter@v6 → v7`
- Internal refactor labelled as a new major version. No input or output breaking changes.
- Our usage passes `tag`, `name`, `config-name`, `publish`, and `latest` — all inputs unchanged in v7.

---

### What changed in `anothrNick/github-tag-action@1.71.0 → 1.75.0`
- Patch/minor releases; no breaking changes.
- No input/output schema changes.

---

### What changed in `helmfile/helmfile-action@v2.4.3 → v2.4.5`
- Patch releases; no breaking changes.

---

### What changed in `digitalocean/action-doctl` (pinned → `@v2` major tag)
- Switched from pinned patch versions (`@v2.5.1`/`@v2.5.2`) to the `@v2` major version tag, aligning with the maintainer's published convention.
- No breaking changes between minor versions.

---

## Testing

Tested via workflow-tests on branch `test-in-312-final-upgrades` (for feature branch tests) and `dev`/`main` (for full release path tests).

**setup-uv@v8.2.0** (`python-uv-test-coverage-simple.yml` via `pytest-quality-coverage.yml`):
https://github.com/repowerednl/workflow-tests/actions/runs/28028226722 ✅ 1m 50s, 100% coverage

**github-tag-action@1.75.0 — prerelease path** (`generate-github-tag.yml` via `test-sphinx-release-pypi.yml`, feature branch):
https://github.com/repowerednl/workflow-tests/actions/runs/28029084060 ✅ 23s, prerelease tag created

**github-tag-action@1.75.0 — full release path** (`generate-github-tag.yml` via `tag-docker-helmfile-kube.yml`, from `dev`):
https://github.com/repowerednl/workflow-tests/actions/runs/28239470226 ✅ "🎉 Creating a full release tag"

**github-tag-action@1.75.0 — full release path after merging main** (confirming no regressions):
https://github.com/repowerednl/workflow-tests/actions/runs/28240535937 ✅ "🎉 Creating a full release tag"

**docker/login-action@v4 + docker/build-push-action@v7 + checkout@v7 + digitalocean/action-doctl@v2 + helmfile-action@v2.4.5** (`tag-docker-helmfile-kube.yml`):
https://github.com/repowerednl/workflow-tests/actions/runs/28239470226 ✅ All action steps passed (doctl install, kubeconfig, Helm login, helmfile, docker build & push). Deploy step failed with `context deadline exceeded` — pre-existing infrastructure issue with the `test` namespace, unrelated to the action upgrades.

**release-drafter@v7 + checkout@v7** (`release-notes-generator.yml` via `test-sphinx-release-pypi.yml`, from `main`):
https://github.com/repowerednl/workflow-tests/actions/runs/28240925706 ✅ `create-release / release` succeeded in 9s — release `v14.0.0` created at https://github.com/repowerednl/workflow-tests/releases/tag/v14.0.0

---

## Not tested — risk accepted

**`actions/setup-python@v6` + `actions/cache/restore@v5` + `actions/cache/save@v5`** (via `python-poetry-cache` composite action)
No org repo currently uses the poetry workflow — all have migrated to uv. The `release-pypi-package.yml` workflow is already marked as "Deprecated — Release PyPi package (use uv instead)". No test target available. Risk accepted: the only breaking change (Node.js 24 runtime) does not apply to GitHub-hosted runners.

---

## Jira ticket

IN-312

## Checks
- [ ] I have added unit tests
- [x] I have tested this locally