### PR TITLE
Add a human comment section to the PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -4,8 +4,11 @@
 ## Summary
 ...
 
+## Human comment
+_Pending — author must write this in their own words before marking the PR Ready for review._
+
 ### Jira ticket
-[PLAT-]
+[TEAM-]
 
 ### Media / Screenshot
 ...


### PR DESCRIPTION
## Summary
Add a `## Human comment` section (after Summary) so every PR carries the author's own words, not AI-generated text. The placeholder defaults to a `Pending` line the author replaces before marking the PR Ready for review. Jira placeholder unified to `[TEAM-]`.

This is the org-wide companion to the create-pr/review-pr skill changes (repowered-conventions#11), which enforce the same section for skill-generated PRs.

## Human comment
Added the human comment section