### PR TITLE
Composite doctl helmfile kube

### DIFF
--- a/.github/workflows/deploy-helmfile-kubernetes.yml
+++ b/.github/workflows/deploy-helmfile-kubernetes.yml
@@ -33,23 +33,13 @@ jobs:
       - name: Checkout ${{ github.repository }}
         uses: actions/checkout@v6
 
-      - name: Install doctl
-        uses: digitalocean/action-doctl@v2.5.1
+      - name: Digital Ocean + Helm setup (Kubernetes)
+        uses: repowerednl/.github/composite-actions/kube-helmfile-setup@main
         with:
-          token: ${{ secrets.digital_ocean_access_token }}
-
-      - name: Save DigitalOcean kubeconfig with short-lived credentials
-        env:
-          expiry-seconds: ${{ vars.KUBE_CRED_EXPIRY_SECOND || 300 }}
-        run: doctl kubernetes cluster kubeconfig save --expiry-seconds ${{ env.expiry-seconds }} ${{ vars.CLUSTER_NAME }}
-
-      - name: Install Helm
-        uses: azure/setup-helm@v5
-        with:
-          version: ${{ vars.HELM_STABLE_VERSION }}
-
-      - name: Helm packages login
-        run: helm registry login ghcr.io --username repowerednl --password ${{ secrets.GITHUB_TOKEN }}
+          digitalocean_token: ${{ secrets.digital_ocean_access_token }}
+          cluster_name: ${{ vars.CLUSTER_NAME }}
+          helm_version: ${{ vars.HELM_STABLE_VERSION }}
+          kube_cred_expiry_seconds: ${{ vars.KUBE_CRED_EXPIRY_SECOND || 300 }}
 
       - name: Deploy
         uses: helmfile/helmfile-action@v2.4.3

--- a/.github/workflows/run-kube-migration.yml
+++ b/.github/workflows/run-kube-migration.yml
@@ -1,5 +1,5 @@
 #TODO(REP-2945): Move migration Job to infra
-name: Run Kubernetes migration Job
+name: "[Deprecated] Run Kubernetes migration Job"
 
 on:
   workflow_call:

--- a/composite-actions/kube-helmfile-setup/action.yml
+++ b/composite-actions/kube-helmfile-setup/action.yml
@@ -1,0 +1,39 @@
+name: Digital Ocean + Helm setup (Kubernetes)
+description: Installs doctl and Helm, saves a short-lived DigitalOcean kubeconfig and logs in to the GHCR Helm registry. Pair with helmfile/helmfile-action for the actual sync.
+
+inputs:
+  digitalocean_token:
+    description: DigitalOcean API token used to fetch the kubeconfig.
+    required: true
+  cluster_name:
+    description: Name of the DigitalOcean Kubernetes cluster.
+    required: true
+  helm_version:
+    description: Helm version to install. Defaults to the org's HELM_STABLE_VERSION.
+    required: false
+    default: v3.20.2
+  kube_cred_expiry_seconds:
+    description: Lifetime of the fetched kubeconfig credentials.
+    required: false
+    default: "300"
+
+runs:
+  using: composite
+  steps:
+    - name: Install doctl
+      uses: digitalocean/action-doctl@v2.5.1
+      with:
+        token: ${{ inputs.digitalocean_token }}
+
+    - name: Save DigitalOcean kubeconfig with short-lived credentials
+      shell: bash
+      run: doctl kubernetes cluster kubeconfig save --expiry-seconds ${{ inputs.kube_cred_expiry_seconds }} ${{ inputs.cluster_name }}
+
+    - name: Install Helm
+      uses: azure/setup-helm@v5
+      with:
+        version: ${{ inputs.helm_version }}
+
+    - name: Helm registry login
+      shell: bash
+      run: helm registry login ghcr.io --username repowerednl --password ${{ github.token }}

--- a/composite-actions/kube-helmfile-setup/action.yml
+++ b/composite-actions/kube-helmfile-setup/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: Name of the DigitalOcean Kubernetes cluster.
     required: true
   helm_version:
-    description: Helm version to install. Defaults to the org's HELM_STABLE_VERSION.
+    description: Helm version to install. Callers typically pass the org's HELM_STABLE_VERSION.
     required: false
     default: v3.20.2
   kube_cred_expiry_seconds:

--- a/workflow-templates/tag-docker-helmfile-kube.yml
+++ b/workflow-templates/tag-docker-helmfile-kube.yml
@@ -45,27 +45,13 @@ jobs:
     secrets:
       docker_hub_access_token: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-#   TODO(REP-2945): Move this step to the repository infra
-#   Should only be active for apps with a database (add job to 'needs' in deploy)
-  run-migrations:
-    uses: repowerednl/.github/.github/workflows/run-kube-migration.yml@main
-    needs: [ tag, github-environment ]
-    with:
-      tag: ${{ needs.tag.outputs.tag }}
-      environment: ${{ needs.github-environment.outputs.environment }}
-    secrets:
-      digital_ocean_access_token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
-      infisical_client_id: ${{ secrets.INFISICAL_CLIENT_ID }}
-      infisical_client_client_secret: ${{ secrets.INFISICAL_CLIENT_SECRET }}
-      infisical_client_project_id: ${{ secrets.INFISICAL_PROJECT_ID }}
-
   deploy:
     strategy:
       matrix:
         selector: [my-app]  # add one entry per release name in deployment/helmfile.yaml.gotmpl
       fail-fast: false
     uses: repowerednl/.github/.github/workflows/deploy-helmfile-kubernetes.yml@main
-    needs: [ docker, run-migrations ]
+    needs: [ docker ]
     with:
       docker_image_tag: ${{ needs.docker.outputs.image_tag }}
       environment: ${{ needs.docker.outputs.environment }}


### PR DESCRIPTION
## Version bump
  #minor
  
  ## Summary
  Extracts the DigitalOcean + Helm cluster setup into a reusable composite action and deprecates the now single-use migration workflow.

  - **New composite action `kube-helmfile-setup`** — bundles the four setup steps (install doctl → save short-lived DO kubeconfig → install Helm → GHCR registry login) so they can be reused by non-infra workflows, not just the helmfile deploy.
  - **`deploy-helmfile-kubernetes.yml`** — replaces the four inline setup steps with a single call to `repowerednl/.github/composite-actions/kube-helmfile-setup@main`. Behavior is unchanged (same doctl/helm versions, expiry, and GHCR login).
  - **`run-kube-migration.yml`** — marked `[Deprecated]` in its name; it was only referenced by one template.
  - **`tag-docker-helmfile-kube.yml` template** — removed the `run-migrations` job (and the obsolete REP-2945 TODO) and rewired `deploy` to `needs: [docker]`. Migrations move to repository infra per REP-2945.

  ## Human comment
- Gives developers more freedom to perform actions on the cluster in workflows by calling this composite 
- Deprecate the migrations reusable as it is only used by `repower-django`

## TODO:
- [ ] Leave branch open until  `repower-django` uses helmfile (with jobs chart) for migrations and this branch is not referenced anymore: 
- [ ] Workflow tests in migrations + deployments in https://github.com/repowerednl/repower-django/pull/2865 will provide the succesfull workflow runs
